### PR TITLE
docs(invitation-feedback): add `none`

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -159,7 +159,7 @@ ALTER TYPE maevsi.invitation_feedback_paper OWNER TO postgres;
 -- Name: TYPE invitation_feedback_paper; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON TYPE maevsi.invitation_feedback_paper IS 'Possible choices on how to receive a paper invitation: paper, digital.';
+COMMENT ON TYPE maevsi.invitation_feedback_paper IS 'Possible choices on how to receive a paper invitation: none, paper, digital.';
 
 
 --

--- a/src/deploy/enum_invitation_feedback_paper.sql
+++ b/src/deploy/enum_invitation_feedback_paper.sql
@@ -8,6 +8,6 @@ CREATE TYPE maevsi.invitation_feedback_paper AS ENUM (
   'digital'
 );
 
-COMMENT ON TYPE maevsi.invitation_feedback_paper IS 'Possible choices on how to receive a paper invitation: paper, digital.';
+COMMENT ON TYPE maevsi.invitation_feedback_paper IS 'Possible choices on how to receive a paper invitation: none, paper, digital.';
 
 COMMIT;


### PR DESCRIPTION
As given a few lines above, `none` is also valid, but was not part of the description yet.