### PR TITLE
fix(contact): account for null in inequality check

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -3225,7 +3225,7 @@ ALTER TABLE maevsi.contact ENABLE ROW LEVEL SECURITY;
 -- Name: contact contact_delete; Type: POLICY; Schema: maevsi; Owner: postgres
 --
 
-CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (((author_account_username = current_setting('jwt.claims.username'::text, true)) AND (account_username <> current_setting('jwt.claims.username'::text, true))));
+CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (((author_account_username = current_setting('jwt.claims.username'::text, true)) AND (account_username IS DISTINCT FROM current_setting('jwt.claims.username'::text, true))));
 
 
 --

--- a/src/deploy/table_contact_policy.sql
+++ b/src/deploy/table_contact_policy.sql
@@ -37,7 +37,7 @@ CREATE POLICY contact_update ON maevsi.contact FOR UPDATE USING (
 CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (
   author_account_username = current_setting('jwt.claims.username', true)::TEXT
   AND
-  account_username != current_setting('jwt.claims.username', true)::TEXT
+  account_username IS DISTINCT FROM current_setting('jwt.claims.username', true)::TEXT
 );
 
 COMMIT;

--- a/src/deploy/table_contact_policy.sql
+++ b/src/deploy/table_contact_policy.sql
@@ -33,7 +33,7 @@ CREATE POLICY contact_update ON maevsi.contact FOR UPDATE USING (
   author_account_username = current_setting('jwt.claims.username', true)::TEXT
 );
 
--- Only allow deletes for contacts authored by the invoker's account.
+-- Only allow deletes for contacts authored by the invoker's account except for the own account's contact.
 CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (
   author_account_username = current_setting('jwt.claims.username', true)::TEXT
   AND


### PR DESCRIPTION
`NULL` is always not inequal to anything. So instead of `!=` or `<>` we need to check if `IS DISTINCT FROM`.