### PR TITLE
fix(report): correct smart tags

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -2035,7 +2035,8 @@ COMMENT ON COLUMN maevsi.report.target_upload_id IS 'The ID of the upload being 
 -- Name: COLUMN report.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.report.created_at IS 'Timestamp of when the report was created, defaults to the current timestamp.';
+COMMENT ON COLUMN maevsi.report.created_at IS '@omit create
+Timestamp of when the report was created, defaults to the current timestamp.';
 
 
 --

--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -1984,14 +1984,15 @@ ALTER TABLE maevsi.report OWNER TO postgres;
 -- Name: TABLE report; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON TABLE maevsi.report IS 'Stores reports made by users on other users, events, or uploads for moderation purposes.';
+COMMENT ON TABLE maevsi.report IS '@omit update,delete
+Stores reports made by users on other users, events, or uploads for moderation purposes.';
 
 
 --
 -- Name: COLUMN report.id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.report.id IS '@omit create,update
+COMMENT ON COLUMN maevsi.report.id IS '@omit create
 Unique identifier for the report, generated randomly using UUIDs.';
 
 

--- a/src/deploy/table_report.sql
+++ b/src/deploy/table_report.sql
@@ -26,7 +26,7 @@ COMMENT ON COLUMN maevsi.report.reason IS 'The reason for the report, provided b
 COMMENT ON COLUMN maevsi.report.target_account_id IS 'The ID of the account being reported, if applicable.';
 COMMENT ON COLUMN maevsi.report.target_event_id IS 'The ID of the event being reported, if applicable.';
 COMMENT ON COLUMN maevsi.report.target_upload_id IS 'The ID of the upload being reported, if applicable.';
-COMMENT ON COLUMN maevsi.report.created_at IS 'Timestamp of when the report was created, defaults to the current timestamp.';
+COMMENT ON COLUMN maevsi.report.created_at IS E'@omit create\nTimestamp of when the report was created, defaults to the current timestamp.';
 COMMENT ON CONSTRAINT report_reason_check ON maevsi.report IS 'Ensures the reason field contains between 1 and 2000 characters.';
 COMMENT ON CONSTRAINT report_check ON maevsi.report IS 'Ensures that the report targets exactly one element (account, event, or upload).';
 COMMENT ON CONSTRAINT report_author_account_id_target_account_id_target_event_id__key ON maevsi.report IS 'Ensures that the same user cannot submit multiple reports on the same element (account, event, or upload).';

--- a/src/deploy/table_report.sql
+++ b/src/deploy/table_report.sql
@@ -19,8 +19,8 @@ CREATE TABLE maevsi.report (
   UNIQUE (author_account_id, target_account_id, target_event_id, target_upload_id)
 );
 
-COMMENT ON TABLE maevsi.report IS 'Stores reports made by users on other users, events, or uploads for moderation purposes.';
-COMMENT ON COLUMN maevsi.report.id IS E'@omit create,update\nUnique identifier for the report, generated randomly using UUIDs.';
+COMMENT ON TABLE maevsi.report IS E'@omit update,delete\nStores reports made by users on other users, events, or uploads for moderation purposes.';
+COMMENT ON COLUMN maevsi.report.id IS E'@omit create\nUnique identifier for the report, generated randomly using UUIDs.';
 COMMENT ON COLUMN maevsi.report.author_account_id IS 'The ID of the user who created the report.';
 COMMENT ON COLUMN maevsi.report.reason IS 'The reason for the report, provided by the reporting user. Must be non-empty and less than 2000 characters.';
 COMMENT ON COLUMN maevsi.report.target_account_id IS 'The ID of the account being reported, if applicable.';


### PR DESCRIPTION
It's prohibited to update or delete reports, so we should not offer such endpoints via the graphql api as they'd fail in all cases.