### PR TITLE
test(account): registration

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -2156,7 +2156,7 @@ COMMENT ON CONSTRAINT report_reason_check ON maevsi.report IS 'Ensures the reaso
 
 CREATE TABLE maevsi_private.account (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    birth_date date NOT NULL,
+    birth_date date,
     created timestamp without time zone DEFAULT now() NOT NULL,
     email_address text NOT NULL,
     email_address_verification uuid DEFAULT gen_random_uuid(),

--- a/src/deploy/table_account_private.sql
+++ b/src/deploy/table_account_private.sql
@@ -7,7 +7,7 @@ BEGIN;
 CREATE TABLE maevsi_private.account (
   id                                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  birth_date                                 DATE NOT NULL,
+  birth_date                                 DATE, -- TODO: evaluate if this should be `NOT NULL` for all new accounts
   created                                    TIMESTAMP NOT NULL DEFAULT NOW(),
   email_address                              TEXT NOT NULL CHECK (char_length(email_address) < 255) UNIQUE, -- no regex check as "a valid email address is one that you can send emails to" (http://www.dominicsayers.com/isemail/)
   email_address_verification                 UUID DEFAULT gen_random_uuid(),

--- a/src/verify/function_account_registration.sql
+++ b/src/verify/function_account_registration.sql
@@ -2,10 +2,24 @@
 
 BEGIN;
 
+SAVEPOINT function_privileges_for_roles;
 DO $$
 BEGIN
-  ASSERT (SELECT pg_catalog.has_function_privilege('maevsi_account', 'maevsi.account_registration(TEXT, TEXT, TEXT, TEXT)', 'EXECUTE'));
-  ASSERT (SELECT pg_catalog.has_function_privilege('maevsi_anonymous', 'maevsi.account_registration(TEXT, TEXT, TEXT, TEXT)', 'EXECUTE'));
+  IF NOT (SELECT pg_catalog.has_function_privilege('maevsi_account', 'maevsi.account_registration(TEXT, TEXT, TEXT, TEXT)', 'EXECUTE')) THEN
+    RAISE EXCEPTION 'Test function_privileges_for_roles failed: maevsi_account does not have EXECUTE privilege';
+  END IF;
+
+  IF NOT (SELECT pg_catalog.has_function_privilege('maevsi_anonymous', 'maevsi.account_registration(TEXT, TEXT, TEXT, TEXT)', 'EXECUTE')) THEN
+    RAISE EXCEPTION 'Test function_privileges_for_roles failed: maevsi_anonymous does not have EXECUTE privilege';
+  END IF;
 END $$;
+ROLLBACK TO SAVEPOINT function_privileges_for_roles;
+
+SAVEPOINT account_creation;
+DO $$
+BEGIN
+  PERFORM maevsi.account_registration('username', 'e@ma.il', 'password', 'en');
+END $$;
+ROLLBACK TO SAVEPOINT account_creation;
 
 ROLLBACK;


### PR DESCRIPTION
I've

- extended the `function_account_registration` test so that exceptions can be pinpointed to a certain line better
- added a function invocation test
- wrapped the tests with a savepoint + rollback, for which the savepoint's variable name conveniently acts as the test name