### PR TITLE
feat(event): assign images to events

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -2002,21 +2002,24 @@ COMMENT ON TABLE maevsi.event_upload IS 'An assignment of an uploaded content (e
 -- Name: COLUMN event_upload.id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.event_upload.id IS '@omit insert,update\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.id IS '@omit create,update
+The event''s internal id for which the invitation is valid.';
 
 
 --
 -- Name: COLUMN event_upload.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update,delete\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update,delete
+The event''s internal id for which the invitation is valid.';
 
 
 --
 -- Name: COLUMN event_upload.upload_id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update,delete\nThe internal id of the uploaded content.';
+COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update,delete
+The internal id of the uploaded content.';
 
 
 --
@@ -3958,8 +3961,7 @@ CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
 --
 
 CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING ((event_id IN ( SELECT event.id
-   FROM maevsi.event
-  WHERE (event.author_account_id = (NULLIF(current_setting('jwt.claims.account_id'::text, true), ''::text))::uuid))));
+   FROM maevsi.event)));
 
 
 --

--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -1406,10 +1406,11 @@ COMMENT ON FUNCTION maevsi.trigger_invitation_update() IS 'Checks if the caller 
 CREATE TABLE maevsi.upload (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     account_id uuid NOT NULL,
+    name text,
     size_byte bigint NOT NULL,
     storage_key text,
-    file_name text,
-    file_type text DEFAULT 'image'::text NOT NULL,
+    type text DEFAULT 'image'::text NOT NULL,
+    CONSTRAINT upload_name_check CHECK (((char_length(name) > 0) AND (char_length(name) < 300))),
     CONSTRAINT upload_size_byte_check CHECK ((size_byte > 0))
 );
 
@@ -1439,6 +1440,13 @@ COMMENT ON COLUMN maevsi.upload.account_id IS 'The uploader''s account id.';
 
 
 --
+-- Name: COLUMN upload.name; Type: COMMENT; Schema: maevsi; Owner: postgres
+--
+
+COMMENT ON COLUMN maevsi.upload.name IS 'The name of the uploaded file.';
+
+
+--
 -- Name: COLUMN upload.size_byte; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
@@ -1453,17 +1461,10 @@ COMMENT ON COLUMN maevsi.upload.storage_key IS 'The upload''s storage key.';
 
 
 --
--- Name: COLUMN upload.file_name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.type; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.upload.file_name IS 'The name of the uploaded file.';
-
-
---
--- Name: COLUMN upload.file_type; Type: COMMENT; Schema: maevsi; Owner: postgres
---
-
-COMMENT ON COLUMN maevsi.upload.file_type IS 'The type of the uploaded file, default is ''image''.';
+COMMENT ON COLUMN maevsi.upload.type IS 'The type of the uploaded file, default is ''image''.';
 
 
 --
@@ -2010,7 +2011,7 @@ The event''s internal id for which the invitation is valid.';
 -- Name: COLUMN event_upload.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update,delete
+COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update
 The event''s internal id for which the invitation is valid.';
 
 
@@ -2018,7 +2019,7 @@ The event''s internal id for which the invitation is valid.';
 -- Name: COLUMN event_upload.upload_id; Type: COMMENT; Schema: maevsi; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update,delete
+COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update
 The internal id of the uploaded content.';
 
 

--- a/src/deploy/table_event_upload.sql
+++ b/src/deploy/table_event_upload.sql
@@ -1,0 +1,17 @@
+-- Deploy maevsi:table_event_upload to pg
+
+BEGIN;
+
+CREATE TABLE maevsi.event_upload (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id          UUID NOT NULL REFERENCES maevsi.event(id),
+  upload_id         UUID NOT NULL REFERENCES maevsi.upload(id),
+  UNIQUE (event_id, upload_id)
+);
+
+COMMENT ON TABLE maevsi.event_upload IS 'An assignment of an uploaded content (e.g. an image) to an event.';
+COMMENT ON COLUMN maevsi.event_upload.id IS '@omit insert,update\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update,delete\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update,delete\nThe internal id of the uploaded content.';
+
+END;

--- a/src/deploy/table_event_upload.sql
+++ b/src/deploy/table_event_upload.sql
@@ -1,17 +1,17 @@
--- Deploy maevsi:table_event_upload to pg
-
 BEGIN;
 
 CREATE TABLE maevsi.event_upload (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
   event_id          UUID NOT NULL REFERENCES maevsi.event(id),
   upload_id         UUID NOT NULL REFERENCES maevsi.upload(id),
+
   UNIQUE (event_id, upload_id)
 );
 
 COMMENT ON TABLE maevsi.event_upload IS 'An assignment of an uploaded content (e.g. an image) to an event.';
 COMMENT ON COLUMN maevsi.event_upload.id IS E'@omit create,update\nThe event''s internal id for which the invitation is valid.';
-COMMENT ON COLUMN maevsi.event_upload.event_id IS E'@omit update,delete\nThe event''s internal id for which the invitation is valid.';
-COMMENT ON COLUMN maevsi.event_upload.upload_id IS E'@omit update,delete\nThe internal id of the uploaded content.';
+COMMENT ON COLUMN maevsi.event_upload.event_id IS E'@omit update\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.upload_id IS E'@omit update\nThe internal id of the uploaded content.';
 
 END;

--- a/src/deploy/table_event_upload.sql
+++ b/src/deploy/table_event_upload.sql
@@ -10,8 +10,8 @@ CREATE TABLE maevsi.event_upload (
 );
 
 COMMENT ON TABLE maevsi.event_upload IS 'An assignment of an uploaded content (e.g. an image) to an event.';
-COMMENT ON COLUMN maevsi.event_upload.id IS '@omit insert,update\nThe event''s internal id for which the invitation is valid.';
-COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update,delete\nThe event''s internal id for which the invitation is valid.';
-COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update,delete\nThe internal id of the uploaded content.';
+COMMENT ON COLUMN maevsi.event_upload.id IS E'@omit create,update\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.event_id IS E'@omit update,delete\nThe event''s internal id for which the invitation is valid.';
+COMMENT ON COLUMN maevsi.event_upload.upload_id IS E'@omit update,delete\nThe internal id of the uploaded content.';
 
 END;

--- a/src/deploy/table_event_upload_policy.sql
+++ b/src/deploy/table_event_upload_policy.sql
@@ -7,15 +7,15 @@ GRANT INSERT, DELETE ON TABLE maevsi.event_upload TO maevsi_account;
 
 ALTER TABLE maevsi.event_upload ENABLE ROW LEVEL SECURITY;
 
--- Only select rows with events authored by the current user.
+-- Only select rows for accessable events where accessability is spcified
+-- by the event_select policy for table event.
 CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING (
   event_id IN (
     SELECT id FROM maevsi.event
-    WHERE author_account_id = NULLIF(current_setting('jwt.claims.account_id', true), '')::UUID
   )
 );
 
--- Only allow inserts for events authored by the current user und uploads of the current_user0.
+-- Only allow inserts for events authored by the current user and for uploads of the current_user0.
 CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
   event_id IN (
     SELECT id FROM maevsi.event
@@ -28,7 +28,7 @@ CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
   )
 );
 
--- Only allow deletes if events is authored by the current user und uploads of the current_user.
+-- Only allow deletes if event is authored by the current user.
 CREATE POLICY event_upload_delete ON maevsi.event_upload FOR DELETE USING (
   event_id IN (
     SELECT id FROM maevsi.event

--- a/src/deploy/table_event_upload_policy.sql
+++ b/src/deploy/table_event_upload_policy.sql
@@ -1,0 +1,39 @@
+-- Deploy maevsi:table_event_upload_policy to pg
+
+BEGIN;
+
+GRANT SELECT ON TABLE maevsi.event_upload TO maevsi_account, maevsi_anonymous;
+GRANT INSERT, DELETE ON TABLE maevsi.event_upload TO maevsi_account;
+
+ALTER TABLE maevsi.event_upload ENABLE ROW LEVEL SECURITY;
+
+-- Only select rows with events authored by the current user.
+CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING (
+  event_id IN (
+    SELECT id FROM maevsi.event
+    WHERE author_account_id = NULLIF(current_setting('jwt.claims.account_id', true), '')::UUID
+  )
+);
+
+-- Only allow inserts for events authored by the current user und uploads of the current_user0.
+CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
+  event_id IN (
+    SELECT id FROM maevsi.event
+    WHERE author_account_id = NULLIF(current_setting('jwt.claims.account_id', true), '')::UUID
+  )
+  AND
+  upload_id IN (
+    SELECT id FROM maevsi.upload
+    WHERE account_id = NULLIF(current_setting('jwt.claims.account_id', true), '')::UUID
+  )
+);
+
+-- Only allow deletes if events is authored by the current user und uploads of the current_user.
+CREATE POLICY event_upload_delete ON maevsi.event_upload FOR DELETE USING (
+  event_id IN (
+    SELECT id FROM maevsi.event
+    WHERE author_account_id = NULLIF(current_setting('jwt.claims.account_id', true), '')::UUID
+  )
+);
+
+COMMIT;

--- a/src/deploy/table_event_upload_policy.sql
+++ b/src/deploy/table_event_upload_policy.sql
@@ -1,5 +1,3 @@
--- Deploy maevsi:table_event_upload_policy to pg
-
 BEGIN;
 
 GRANT SELECT ON TABLE maevsi.event_upload TO maevsi_account, maevsi_anonymous;
@@ -7,7 +5,7 @@ GRANT INSERT, DELETE ON TABLE maevsi.event_upload TO maevsi_account;
 
 ALTER TABLE maevsi.event_upload ENABLE ROW LEVEL SECURITY;
 
--- Only select rows for accessable events where accessability is spcified
+-- Only select rows for accessable events where accessability is specified
 -- by the event_select policy for table event.
 CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING (
   event_id IN (
@@ -15,7 +13,7 @@ CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING (
   )
 );
 
--- Only allow inserts for events authored by the current user and for uploads of the current_user0.
+-- Only allow inserts for events authored by the current user and for uploads of the current_user.
 CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
   event_id IN (
     SELECT id FROM maevsi.event

--- a/src/deploy/table_upload.sql
+++ b/src/deploy/table_upload.sql
@@ -8,7 +8,9 @@ CREATE TABLE maevsi.upload (
   id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   account_id     UUID NOT NULL REFERENCES maevsi.account(id),
   size_byte      BIGINT NOT NULL CHECK (size_byte > 0),
-  storage_key    TEXT UNIQUE
+  storage_key    TEXT UNIQUE,
+  file_name      TEXT,
+  file_type      TEXT NOT NULL DEFAULT 'image'
 );
 
 COMMENT ON TABLE maevsi.upload IS 'An upload.';
@@ -16,5 +18,7 @@ COMMENT ON COLUMN maevsi.upload.id IS E'@omit create,update\nThe upload''s inter
 COMMENT ON COLUMN maevsi.upload.account_id IS 'The uploader''s account id.';
 COMMENT ON COLUMN maevsi.upload.size_byte IS 'The upload''s size in bytes.';
 COMMENT ON COLUMN maevsi.upload.storage_key IS 'The upload''s storage key.';
+COMMENT ON COLUMN maevsi.upload.file_name IS 'The name of the uploaded file.';
+COMMENT ON COLUMN maevsi.upload.file_type IS 'The type of the uploaded file, default is ''image''.';
 
 COMMIT;

--- a/src/deploy/table_upload.sql
+++ b/src/deploy/table_upload.sql
@@ -6,19 +6,20 @@ BEGIN;
 
 CREATE TABLE maevsi.upload (
   id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
   account_id     UUID NOT NULL REFERENCES maevsi.account(id),
+  name           TEXT CHECK (char_length("name") > 0 AND char_length("name") < 300),
   size_byte      BIGINT NOT NULL CHECK (size_byte > 0),
   storage_key    TEXT UNIQUE,
-  file_name      TEXT,
-  file_type      TEXT NOT NULL DEFAULT 'image'
+  type           TEXT NOT NULL DEFAULT 'image'
 );
 
 COMMENT ON TABLE maevsi.upload IS 'An upload.';
 COMMENT ON COLUMN maevsi.upload.id IS E'@omit create,update\nThe upload''s internal id.';
 COMMENT ON COLUMN maevsi.upload.account_id IS 'The uploader''s account id.';
+COMMENT ON COLUMN maevsi.upload.name IS 'The name of the uploaded file.';
 COMMENT ON COLUMN maevsi.upload.size_byte IS 'The upload''s size in bytes.';
 COMMENT ON COLUMN maevsi.upload.storage_key IS 'The upload''s storage key.';
-COMMENT ON COLUMN maevsi.upload.file_name IS 'The name of the uploaded file.';
-COMMENT ON COLUMN maevsi.upload.file_type IS 'The type of the uploaded file, default is ''image''.';
+COMMENT ON COLUMN maevsi.upload.type IS 'The type of the uploaded file, default is ''image''.';
 
 COMMIT;

--- a/src/revert/table_event_upload.sql
+++ b/src/revert/table_event_upload.sql
@@ -1,0 +1,7 @@
+-- Revert maevsi:table_event_upload from pg
+
+BEGIN;
+
+DROP TABLE maevsi.event_upload;
+
+COMMIT;

--- a/src/revert/table_event_upload.sql
+++ b/src/revert/table_event_upload.sql
@@ -1,5 +1,3 @@
--- Revert maevsi:table_event_upload from pg
-
 BEGIN;
 
 DROP TABLE maevsi.event_upload;

--- a/src/revert/table_event_upload_policy.sql
+++ b/src/revert/table_event_upload_policy.sql
@@ -1,5 +1,3 @@
--- Revert maevsi:table_event_upload_policy to pg
-
 BEGIN;
 
 DROP POLICY event_upload_select ON maevsi.event_upload;

--- a/src/revert/table_event_upload_policy.sql
+++ b/src/revert/table_event_upload_policy.sql
@@ -1,0 +1,9 @@
+-- Revert maevsi:table_event_upload_policy to pg
+
+BEGIN;
+
+DROP POLICY event_upload_select ON maevsi.event_upload;
+DROP POLICY event_upload_insert ON maevsi.event_upload;
+DROP POLICY event_upload_delete ON maevsi.event_upload;
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -75,5 +75,5 @@ table_account_social_network_policy [schema_public table_account_social_network 
 enum_event_size [schema_public] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Possible event sizes: small, medium, large, huge.
 table_account_preference_event_size  [schema_public table_account_public enum_event_size] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Table for the user accounts' preferred event sizes (M:N relationship).
 table_account_preference_event_size_policy  [schema_public table_account_preference_event_size role_account] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Security policy for table account_event_size_pref.
-table_event_upload [schema_public table_event table_upload] 1970-01-01T00:00:00Z JSven Thelemann <sven.thelemann@t-online.de> # Add table event_upload.
-table_event_upload_policy [schema_public table_event_upload table_event table_upload role_account role_anonymous] 1970-01-01T00:00:00Z JSven Thelemann <sven.thelemann@t-online.de> # Grants and policies for table event_upload.
+table_event_upload [schema_public table_event table_upload] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add table event_upload.
+table_event_upload_policy [schema_public table_event_upload table_event table_upload role_account role_anonymous] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Grants and policies for table event_upload.

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -75,3 +75,5 @@ table_account_social_network_policy [schema_public table_account_social_network 
 enum_event_size [schema_public] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Possible event sizes: small, medium, large, huge.
 table_account_preference_event_size  [schema_public table_account_public enum_event_size] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Table for the user accounts' preferred event sizes (M:N relationship).
 table_account_preference_event_size_policy  [schema_public table_account_preference_event_size role_account] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Security policy for table account_event_size_pref.
+table_event_upload [schema_public table_event table_upload] 1970-01-01T00:00:00Z JSven Thelemann <sven.thelemann@t-online.de> # Add table event_upload.
+table_event_upload_policy [schema_public table_event_upload table_event table_upload role_account role_anonymous] 1970-01-01T00:00:00Z JSven Thelemann <sven.thelemann@t-online.de> # Grants and policies for table event_upload.

--- a/src/verify/table_event_upload.sql
+++ b/src/verify/table_event_upload.sql
@@ -1,9 +1,6 @@
--- Verify maevsi:table_event_upload on pg
-
 BEGIN;
 
 SELECT id,
        event_id,
        upload_id
 FROM maevsi.event_upload WHERE FALSE;
-

--- a/src/verify/table_event_upload.sql
+++ b/src/verify/table_event_upload.sql
@@ -1,0 +1,9 @@
+-- Verify maevsi:table_event_upload on pg
+
+BEGIN;
+
+SELECT id,
+       event_id,
+       upload_id
+FROM maevsi.event_upload WHERE FALSE;
+

--- a/src/verify/table_event_upload_policy.sql
+++ b/src/verify/table_event_upload_policy.sql
@@ -1,0 +1,21 @@
+-- Verify maevsi:table_event_upload_policy to pg
+
+BEGIN;
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_table_privilege('maevsi_account', 'maevsi.event_upload', 'SELECT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('maevsi_account', 'maevsi.event_upload', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_account', 'maevsi.event_upload', 'UPDATE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('maevsi_account', 'maevsi.event_upload', 'DELETE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('maevsi_anonymous', 'maevsi.event_upload', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_anonymous', 'maevsi.event_upload', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_anonymous', 'maevsi.event_upload', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_anonymous', 'maevsi.event_upload', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_tusd', 'maevsi.event_upload', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_tusd', 'maevsi.event_upload', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_tusd', 'maevsi.event_upload', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('maevsi_tusd', 'maevsi.event_upload', 'DELETE'));
+END $$;
+
+ROLLBACK;

--- a/src/verify/table_event_upload_policy.sql
+++ b/src/verify/table_event_upload_policy.sql
@@ -1,5 +1,3 @@
--- Verify maevsi:table_event_upload_policy to pg
-
 BEGIN;
 
 DO $$

--- a/src/verify/table_upload.sql
+++ b/src/verify/table_upload.sql
@@ -4,10 +4,10 @@ BEGIN;
 
 SELECT id,
        account_id,
+       name,
        size_byte,
        storage_key,
-       file_name,
-       file_type
+       type
 FROM maevsi.upload WHERE FALSE;
 
 ROLLBACK;

--- a/src/verify/table_upload.sql
+++ b/src/verify/table_upload.sql
@@ -5,7 +5,9 @@ BEGIN;
 SELECT id,
        account_id,
        size_byte,
-       storage_key
+       storage_key,
+       file_name,
+       file_type
 FROM maevsi.upload WHERE FALSE;
 
 ROLLBACK;


### PR DESCRIPTION
A new table event_upload is introduced to store the connection between uploaded images and events. If more than one image is assigned to an event the sorting of these images  will be based on the image file name. To enable this, file_name is now an additional column in the table upload. This table has another new column, file_type, with the default value 'image' as currently only image files can be uploaded.