### PR TITLE
feat(account)!: rename `created` column to `created_at`

### DIFF
--- a/schema/schema.definition.sql
+++ b/schema/schema.definition.sql
@@ -2273,7 +2273,7 @@ COMMENT ON CONSTRAINT report_reason_check ON maevsi.report IS 'Ensures the reaso
 CREATE TABLE maevsi_private.account (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     birth_date date,
-    created timestamp without time zone DEFAULT now() NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
     email_address text NOT NULL,
     email_address_verification uuid DEFAULT gen_random_uuid(),
     email_address_verification_valid_until timestamp without time zone,
@@ -2310,10 +2310,10 @@ COMMENT ON COLUMN maevsi_private.account.birth_date IS 'The account owner''s dat
 
 
 --
--- Name: COLUMN account.created; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.created_at; Type: COMMENT; Schema: maevsi_private; Owner: postgres
 --
 
-COMMENT ON COLUMN maevsi_private.account.created IS 'Timestamp at which the account was last active.';
+COMMENT ON COLUMN maevsi_private.account.created_at IS 'Timestamp at which the account was last active.';
 
 
 --

--- a/src/deploy/table_account_private.sql
+++ b/src/deploy/table_account_private.sql
@@ -4,7 +4,7 @@ CREATE TABLE maevsi_private.account (
   id                                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
   birth_date                                 DATE, -- TODO: evaluate if this should be `NOT NULL` for all new accounts
-  created                                    TIMESTAMP NOT NULL DEFAULT NOW(),
+  created_at                                 TIMESTAMP NOT NULL DEFAULT NOW(),
   email_address                              TEXT NOT NULL CHECK (char_length(email_address) < 255) UNIQUE, -- no regex check as "a valid email address is one that you can send emails to" (http://www.dominicsayers.com/isemail/)
   email_address_verification                 UUID DEFAULT gen_random_uuid(),
   email_address_verification_valid_until     TIMESTAMP,
@@ -18,7 +18,7 @@ CREATE TABLE maevsi_private.account (
 COMMENT ON TABLE maevsi_private.account IS 'Private account data.';
 COMMENT ON COLUMN maevsi_private.account.id IS 'The account''s internal id.';
 COMMENT ON COLUMN maevsi_private.account.birth_date IS 'The account owner''s date of birth.';
-COMMENT ON COLUMN maevsi_private.account.created IS 'Timestamp at which the account was last active.';
+COMMENT ON COLUMN maevsi_private.account.created_at IS 'Timestamp at which the account was last active.';
 COMMENT ON COLUMN maevsi_private.account.email_address IS 'The account''s email address for account related information.';
 COMMENT ON COLUMN maevsi_private.account.email_address_verification IS 'The UUID used to verify an email address, or null if already verified.';
 COMMENT ON COLUMN maevsi_private.account.email_address_verification_valid_until IS 'The timestamp until which an email address verification is valid.';

--- a/src/verify/table_account_private.sql
+++ b/src/verify/table_account_private.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 SELECT id,
        birth_date,
-       created,
+       created_at,
        email_address,
        email_address_verification,
        email_address_verification_valid_until,


### PR DESCRIPTION
Align column name to column names in other tables.
I've created a `beta` branch for this breaking change and more to come.

See #78.