### PR TITLE
refactor: use standardized timestamp notation

### DIFF
--- a/src/deploy/function_account_email_address_verification.sql
+++ b/src/deploy/function_account_email_address_verification.sql
@@ -15,7 +15,7 @@ BEGIN
     RAISE 'Unknown verification code!' USING ERRCODE = 'no_data_found';
   END IF;
 
-  IF (_account.email_address_verification_valid_until < NOW()) THEN
+  IF (_account.email_address_verification_valid_until < CURRENT_TIMESTAMP) THEN
     RAISE 'Verification code expired!' USING ERRCODE = 'object_not_in_prerequisite_state';
   END IF;
 

--- a/src/deploy/function_account_password_reset.sql
+++ b/src/deploy/function_account_password_reset.sql
@@ -20,7 +20,7 @@ BEGIN
     RAISE 'Unknown reset code!' USING ERRCODE = 'no_data_found';
   END IF;
 
-  IF (_account.password_reset_verification_valid_until < NOW()) THEN
+  IF (_account.password_reset_verification_valid_until < CURRENT_TIMESTAMP) THEN
     RAISE 'Reset code expired!' USING ERRCODE = 'object_not_in_prerequisite_state';
   END IF;
 

--- a/src/deploy/function_account_registration.sql
+++ b/src/deploy/function_account_registration.sql
@@ -24,7 +24,7 @@ BEGIN
   END IF;
 
   INSERT INTO maevsi_private.account(email_address, password_hash, last_activity) VALUES
-    (account_registration.email_address, maevsi.crypt(account_registration.password, maevsi.gen_salt('bf')), NOW())
+    (account_registration.email_address, maevsi.crypt(account_registration.password, maevsi.gen_salt('bf')), CURRENT_TIMESTAMP)
     RETURNING * INTO _new_account_private;
 
   INSERT INTO maevsi.account(id, username) VALUES

--- a/src/deploy/function_authenticate.sql
+++ b/src/deploy/function_authenticate.sql
@@ -7,7 +7,7 @@ CREATE FUNCTION maevsi.authenticate(
 DECLARE
   _account_id UUID;
   _jwt_id UUID := gen_random_uuid();
-  _jwt_exp BIGINT := EXTRACT(EPOCH FROM ((SELECT date_trunc('second', NOW()::TIMESTAMP)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL));
+  _jwt_exp BIGINT := EXTRACT(EPOCH FROM ((SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL));
   _jwt maevsi.jwt;
 BEGIN
   IF ($1 = '' AND $2 = '') THEN

--- a/src/deploy/function_jwt_refresh.sql
+++ b/src/deploy/function_jwt_refresh.sql
@@ -4,7 +4,7 @@ CREATE FUNCTION maevsi.jwt_refresh(
   jwt_id UUID
 ) RETURNS maevsi.jwt AS $$
 DECLARE
-  _epoch_now BIGINT := EXTRACT(EPOCH FROM (SELECT date_trunc('second', NOW()::TIMESTAMP)));
+  _epoch_now BIGINT := EXTRACT(EPOCH FROM (SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP)));
   _jwt maevsi.jwt;
 BEGIN
   SELECT (token).id, (token).account_id, (token).account_username, (token)."exp", (token).invitations, (token).role INTO _jwt
@@ -16,7 +16,7 @@ BEGIN
     RETURN NULL;
   ELSE
     UPDATE maevsi_private.jwt
-    SET token.exp = EXTRACT(EPOCH FROM ((SELECT date_trunc('second', NOW()::TIMESTAMP)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL))
+    SET token.exp = EXTRACT(EPOCH FROM ((SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL))
     WHERE id = $1;
 
     UPDATE maevsi_private.account

--- a/src/deploy/table_account_private.sql
+++ b/src/deploy/table_account_private.sql
@@ -4,11 +4,11 @@ CREATE TABLE maevsi_private.account (
   id                                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
   birth_date                                 DATE, -- TODO: evaluate if this should be `NOT NULL` for all new accounts
-  created                                    TIMESTAMP NOT NULL DEFAULT NOW(),
+  created                                    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   email_address                              TEXT NOT NULL CHECK (char_length(email_address) < 255) UNIQUE, -- no regex check as "a valid email address is one that you can send emails to" (http://www.dominicsayers.com/isemail/)
   email_address_verification                 UUID DEFAULT gen_random_uuid(),
   email_address_verification_valid_until     TIMESTAMP,
-  last_activity                              TIMESTAMP NOT NULL DEFAULT NOW(),
+  last_activity                              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   password_hash                              TEXT NOT NULL,
   password_reset_verification                UUID,
   password_reset_verification_valid_until    TIMESTAMP,
@@ -34,7 +34,7 @@ CREATE FUNCTION maevsi_private.account_email_address_verification_valid_until() 
       NEW.email_address_verification_valid_until = NULL;
     ELSE
       IF ((OLD IS NULL) OR (OLD.email_address_verification IS DISTINCT FROM NEW.email_address_verification)) THEN
-        NEW.email_address_verification_valid_until = (SELECT (NOW() + INTERVAL '1 day')::TIMESTAMP);
+        NEW.email_address_verification_valid_until = (SELECT (CURRENT_TIMESTAMP + INTERVAL '1 day')::TIMESTAMP);
       END IF;
     END IF;
 
@@ -52,7 +52,7 @@ CREATE FUNCTION maevsi_private.account_password_reset_verification_valid_until()
       NEW.password_reset_verification_valid_until = NULL;
     ELSE
       IF ((OLD IS NULL) OR (OLD.password_reset_verification IS DISTINCT FROM NEW.password_reset_verification)) THEN
-        NEW.password_reset_verification_valid_until = (SELECT (NOW() + INTERVAL '2 hours')::TIMESTAMP);
+        NEW.password_reset_verification_valid_until = (SELECT (CURRENT_TIMESTAMP + INTERVAL '2 hours')::TIMESTAMP);
       END IF;
     END IF;
 

--- a/src/deploy/table_notification.sql
+++ b/src/deploy/table_notification.sql
@@ -5,7 +5,7 @@ CREATE TABLE maevsi_private.notification (
   channel            TEXT NOT NULL,
   is_acknowledged    BOOLEAN,
   payload            TEXT NOT NULL CHECK (octet_length(payload) <= 8000),
-  "timestamp"        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+  "timestamp"        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 COMMENT ON TABLE maevsi_private.notification IS 'A notification.';


### PR DESCRIPTION
`CURRENT_TIMESTAMP` should be standard SQL, `NOW` a PostgreSQL-specific alias. Let's use the standardized variant as discussed.