### PR TITLE
feat(extension)!: add postgis

### DIFF
--- a/src/deploy/extension_postgis.sql
+++ b/src/deploy/extension_postgis.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE EXTENSION postgis WITH SCHEMA maevsi;
+
+COMMENT ON EXTENSION postgis IS 'Functions to work with geospatial data.';
+
+COMMIT;

--- a/src/revert/extension_postgis.sql
+++ b/src/revert/extension_postgis.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP EXTENSION postgis;
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -92,3 +92,4 @@ table_event_recommendation_policy [schema_public table_event_recommendation role
 table_event_favourite [schema_public table_account_public table_event] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # A table for the user accounts' favourite events.
 table_event_favourite_policy [schema_public table_account_public table_event role_account] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Policy for table event_favourite.
 test_account_blocking [schema_test] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Test cases for account blocking.
+extension_postgis [schema_public] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+maevsi/sqitch@jonas-thelemann.de> # Add functions to work with geospatial data.

--- a/src/verify/extension_postgis.sql
+++ b/src/verify/extension_postgis.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+SELECT 1/count(*) FROM pg_extension WHERE extname = 'postgis';
+SELECT has_function_privilege('maevsi.ST_DWithin(maevsi.geometry, maevsi.geometry, double precision)', 'EXECUTE');
+
+ROLLBACK;

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -94,6 +94,20 @@ COMMENT ON EXTENSION pgcrypto IS 'Provides password hashing functions.';
 
 
 --
+-- Name: postgis; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS postgis WITH SCHEMA maevsi;
+
+
+--
+-- Name: EXTENSION postgis; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION postgis IS 'Functions to work with geospatial data.';
+
+
+--
 -- Name: achievement_type; Type: TYPE; Schema: maevsi; Owner: postgres
 --
 
@@ -5324,6 +5338,678 @@ GRANT USAGE ON SCHEMA maevsi TO maevsi_tusd;
 
 
 --
+-- Name: FUNCTION box2d_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2d_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box2d_out(maevsi.box2d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2d_out(maevsi.box2d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box2df_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2df_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box2df_out(maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2df_out(maevsi.box2df) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box3d_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box3d_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box3d_out(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box3d_out(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_analyze(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_analyze(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_in(cstring, oid, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_in(cstring, oid, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_out(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_out(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_recv(internal, oid, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_recv(internal, oid, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_send(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_send(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_typmod_in(cstring[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_typmod_in(cstring[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_typmod_out(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_typmod_out(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_analyze(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_analyze(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_out(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_out(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_recv(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_recv(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_send(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_send(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_typmod_in(cstring[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_typmod_in(cstring[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_typmod_out(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_typmod_out(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gidx_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gidx_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gidx_out(maevsi.gidx); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gidx_out(maevsi.gidx) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION spheroid_in(cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.spheroid_in(cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION spheroid_out(maevsi.spheroid); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.spheroid_out(maevsi.spheroid) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box3d(maevsi.box2d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box3d(maevsi.box2d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(maevsi.box2d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(maevsi.box2d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box2d(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2d(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION bytea(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.bytea(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography(maevsi.geography, integer, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography(maevsi.geography, integer, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box2d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box2d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION box3d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box3d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION bytea(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.bytea(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(maevsi.geometry, integer, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(maevsi.geometry, integer, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION "json"(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi."json"(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION jsonb(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.jsonb(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION path(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.path(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION point(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.point(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION polygon(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.polygon(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION text(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.text(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(path); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(path) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(point); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(point) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(polygon); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(polygon) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_deprecate(oldname text, newname text, version text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_deprecate(oldname text, newname text, version text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_index_extent(tbl regclass, col text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_index_extent(tbl regclass, col text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_join_selectivity(regclass, text, regclass, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_join_selectivity(regclass, text, regclass, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_pgsql_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_pgsql_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_scripts_pgsql_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_scripts_pgsql_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_selectivity(tbl regclass, att_name text, geom maevsi.geometry, mode text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_selectivity(tbl regclass, att_name text, geom maevsi.geometry, mode text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _postgis_stats(tbl regclass, att_name text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._postgis_stats(tbl regclass, att_name text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_3ddfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_3ddfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_3ddwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_3ddwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_3dintersects(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_3dintersects(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_asgml(integer, maevsi.geometry, integer, integer, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_asgml(integer, maevsi.geometry, integer, integer, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_asx3d(integer, maevsi.geometry, integer, integer, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_asx3d(integer, maevsi.geometry, integer, integer, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_bestsrid(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_bestsrid(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_bestsrid(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_bestsrid(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_concavehull(param_inputgeom maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_concavehull(param_inputgeom maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_contains(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_contains(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_containsproperly(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_containsproperly(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_coveredby(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_coveredby(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_coveredby(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_coveredby(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_covers(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_covers(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_covers(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_covers(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_crosses(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_crosses(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_dfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_dfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_distancetree(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_distancetree(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_distancetree(maevsi.geography, maevsi.geography, double precision, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_distancetree(maevsi.geography, maevsi.geography, double precision, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_distanceuncached(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_distanceuncached(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_distanceuncached(maevsi.geography, maevsi.geography, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_distanceuncached(maevsi.geography, maevsi.geography, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_distanceuncached(maevsi.geography, maevsi.geography, double precision, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_distanceuncached(maevsi.geography, maevsi.geography, double precision, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_dwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_dwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_dwithin(geog1 maevsi.geography, geog2 maevsi.geography, tolerance double precision, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_dwithin(geog1 maevsi.geography, geog2 maevsi.geography, tolerance double precision, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_dwithinuncached(maevsi.geography, maevsi.geography, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_dwithinuncached(maevsi.geography, maevsi.geography, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_dwithinuncached(maevsi.geography, maevsi.geography, double precision, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_dwithinuncached(maevsi.geography, maevsi.geography, double precision, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_equals(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_equals(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_expand(maevsi.geography, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_expand(maevsi.geography, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_geomfromgml(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_geomfromgml(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_intersects(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_intersects(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_linecrossingdirection(line1 maevsi.geometry, line2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_linecrossingdirection(line1 maevsi.geometry, line2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_longestline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_longestline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_maxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_maxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_orderingequals(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_orderingequals(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_pointoutside(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_pointoutside(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_sortablehash(geom maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_sortablehash(geom maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_touches(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_touches(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_voronoi(g1 maevsi.geometry, clip maevsi.geometry, tolerance double precision, return_polygons boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_voronoi(g1 maevsi.geometry, clip maevsi.geometry, tolerance double precision, return_polygons boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION _st_within(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi._st_within(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION account_delete(password text); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
@@ -5400,6 +6086,27 @@ GRANT ALL ON FUNCTION maevsi.achievement_unlock(code uuid, alias text) TO maevsi
 
 
 --
+-- Name: FUNCTION addgeometrycolumn(table_name character varying, column_name character varying, new_srid integer, new_type character varying, new_dim integer, use_typmod boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.addgeometrycolumn(table_name character varying, column_name character varying, new_srid integer, new_type character varying, new_dim integer, use_typmod boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION addgeometrycolumn(schema_name character varying, table_name character varying, column_name character varying, new_srid integer, new_type character varying, new_dim integer, use_typmod boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.addgeometrycolumn(schema_name character varying, table_name character varying, column_name character varying, new_srid integer, new_type character varying, new_dim integer, use_typmod boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION addgeometrycolumn(catalog_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer, new_type character varying, new_dim integer, use_typmod boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.addgeometrycolumn(catalog_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer, new_type character varying, new_dim integer, use_typmod boolean) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION armor(bytea); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
@@ -5420,6 +6127,34 @@ REVOKE ALL ON FUNCTION maevsi.armor(bytea, text[], text[]) FROM PUBLIC;
 REVOKE ALL ON FUNCTION maevsi.authenticate(username text, password text) FROM PUBLIC;
 GRANT ALL ON FUNCTION maevsi.authenticate(username text, password text) TO maevsi_account;
 GRANT ALL ON FUNCTION maevsi.authenticate(username text, password text) TO maevsi_anonymous;
+
+
+--
+-- Name: FUNCTION box3dtobox(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.box3dtobox(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION contains_2d(maevsi.box2df, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.contains_2d(maevsi.box2df, maevsi.box2df) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION contains_2d(maevsi.box2df, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.contains_2d(maevsi.box2df, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION contains_2d(maevsi.geometry, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.contains_2d(maevsi.geometry, maevsi.box2df) FROM PUBLIC;
 
 
 --
@@ -5465,6 +6200,48 @@ REVOKE ALL ON FUNCTION maevsi.digest(text, text) FROM PUBLIC;
 
 
 --
+-- Name: FUNCTION dropgeometrycolumn(table_name character varying, column_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrycolumn(table_name character varying, column_name character varying) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION dropgeometrycolumn(schema_name character varying, table_name character varying, column_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrycolumn(schema_name character varying, table_name character varying, column_name character varying) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION dropgeometrycolumn(catalog_name character varying, schema_name character varying, table_name character varying, column_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrycolumn(catalog_name character varying, schema_name character varying, table_name character varying, column_name character varying) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION dropgeometrytable(table_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrytable(table_name character varying) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION dropgeometrytable(schema_name character varying, table_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrytable(schema_name character varying, table_name character varying) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION dropgeometrytable(catalog_name character varying, schema_name character varying, table_name character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.dropgeometrytable(catalog_name character varying, schema_name character varying, table_name character varying) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION encrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
@@ -5476,6 +6253,13 @@ REVOKE ALL ON FUNCTION maevsi.encrypt(bytea, bytea, text) FROM PUBLIC;
 --
 
 REVOKE ALL ON FUNCTION maevsi.encrypt_iv(bytea, bytea, bytea, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION equals(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.equals(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
 
 
 --
@@ -5531,6 +6315,13 @@ GRANT ALL ON FUNCTION maevsi.events_organized() TO maevsi_anonymous;
 
 
 --
+-- Name: FUNCTION find_srid(character varying, character varying, character varying); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.find_srid(character varying, character varying, character varying) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION gen_random_bytes(integer); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
@@ -5556,6 +6347,727 @@ REVOKE ALL ON FUNCTION maevsi.gen_salt(text) FROM PUBLIC;
 --
 
 REVOKE ALL ON FUNCTION maevsi.gen_salt(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geog_brin_inclusion_add_value(internal, internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geog_brin_inclusion_add_value(internal, internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_cmp(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_cmp(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_distance_knn(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_distance_knn(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_eq(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_eq(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_ge(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_ge(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_compress(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_compress(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_consistent(internal, maevsi.geography, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_consistent(internal, maevsi.geography, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_decompress(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_decompress(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_distance(internal, maevsi.geography, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_distance(internal, maevsi.geography, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_penalty(internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_penalty(internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_picksplit(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_picksplit(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_same(maevsi.box2d, maevsi.box2d, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_same(maevsi.box2d, maevsi.box2d, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gist_union(bytea, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gist_union(bytea, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_gt(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_gt(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_le(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_le(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_lt(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_lt(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_overlaps(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_overlaps(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_choose_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_choose_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_compress_nd(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_compress_nd(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_config_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_config_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_inner_consistent_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_inner_consistent_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_leaf_consistent_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_leaf_consistent_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geography_spgist_picksplit_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geography_spgist_picksplit_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geom2d_brin_inclusion_add_value(internal, internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geom2d_brin_inclusion_add_value(internal, internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geom3d_brin_inclusion_add_value(internal, internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geom3d_brin_inclusion_add_value(internal, internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geom4d_brin_inclusion_add_value(internal, internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geom4d_brin_inclusion_add_value(internal, internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_above(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_above(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_below(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_below(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_cmp(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_cmp(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_contained_3d(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_contained_3d(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_contains(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_contains(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_contains_3d(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_contains_3d(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_contains_nd(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_contains_nd(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_distance_box(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_distance_box(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_distance_centroid(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_distance_centroid(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_distance_centroid_nd(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_distance_centroid_nd(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_distance_cpa(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_distance_cpa(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_eq(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_eq(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_ge(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_ge(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_compress_2d(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_compress_2d(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_compress_nd(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_compress_nd(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_consistent_2d(internal, maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_consistent_2d(internal, maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_consistent_nd(internal, maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_consistent_nd(internal, maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_decompress_2d(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_decompress_2d(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_decompress_nd(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_decompress_nd(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_distance_2d(internal, maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_distance_2d(internal, maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_distance_nd(internal, maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_distance_nd(internal, maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_penalty_2d(internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_penalty_2d(internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_penalty_nd(internal, internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_penalty_nd(internal, internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_picksplit_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_picksplit_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_picksplit_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_picksplit_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_same_2d(geom1 maevsi.geometry, geom2 maevsi.geometry, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_same_2d(geom1 maevsi.geometry, geom2 maevsi.geometry, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_same_nd(maevsi.geometry, maevsi.geometry, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_same_nd(maevsi.geometry, maevsi.geometry, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_sortsupport_2d(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_sortsupport_2d(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_union_2d(bytea, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_union_2d(bytea, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gist_union_nd(bytea, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gist_union_nd(bytea, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_gt(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_gt(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_hash(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_hash(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_le(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_le(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_left(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_left(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_lt(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_lt(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_neq(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_neq(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overabove(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overabove(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overbelow(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overbelow(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overlaps_3d(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overlaps_3d(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overlaps_nd(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overlaps_nd(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overleft(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overleft(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_overright(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_overright(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_right(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_right(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_same(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_same(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_same_3d(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_same_3d(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_same_nd(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_same_nd(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_sortsupport(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_sortsupport(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_choose_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_choose_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_choose_3d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_choose_3d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_choose_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_choose_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_compress_2d(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_compress_2d(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_compress_3d(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_compress_3d(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_compress_nd(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_compress_nd(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_config_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_config_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_config_3d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_config_3d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_config_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_config_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_inner_consistent_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_inner_consistent_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_inner_consistent_3d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_inner_consistent_3d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_inner_consistent_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_inner_consistent_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_leaf_consistent_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_leaf_consistent_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_leaf_consistent_3d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_leaf_consistent_3d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_leaf_consistent_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_leaf_consistent_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_picksplit_2d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_picksplit_2d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_picksplit_3d(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_picksplit_3d(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_spgist_picksplit_nd(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_spgist_picksplit_nd(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_within(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_within(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometry_within_nd(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometry_within_nd(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometrytype(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometrytype(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geometrytype(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geometrytype(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geomfromewkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geomfromewkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION geomfromewkt(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.geomfromewkt(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION get_proj4_from_srid(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.get_proj4_from_srid(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gserialized_gist_joinsel_2d(internal, oid, internal, smallint); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gserialized_gist_joinsel_2d(internal, oid, internal, smallint) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gserialized_gist_joinsel_nd(internal, oid, internal, smallint); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gserialized_gist_joinsel_nd(internal, oid, internal, smallint) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gserialized_gist_sel_2d(internal, oid, internal, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gserialized_gist_sel_2d(internal, oid, internal, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION gserialized_gist_sel_nd(internal, oid, internal, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.gserialized_gist_sel_nd(internal, oid, internal, integer) FROM PUBLIC;
 
 
 --
@@ -5617,6 +7129,27 @@ GRANT ALL ON FUNCTION maevsi.invoker_account_id() TO maevsi_anonymous;
 
 
 --
+-- Name: FUNCTION is_contained_2d(maevsi.box2df, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.is_contained_2d(maevsi.box2df, maevsi.box2df) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION is_contained_2d(maevsi.box2df, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.is_contained_2d(maevsi.box2df, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION is_contained_2d(maevsi.geometry, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.is_contained_2d(maevsi.geometry, maevsi.box2df) FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION jwt_refresh(jwt_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
@@ -5638,6 +7171,286 @@ REVOKE ALL ON FUNCTION maevsi.legal_term_change() FROM PUBLIC;
 
 REVOKE ALL ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) FROM PUBLIC;
 GRANT ALL ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) TO maevsi_anonymous;
+
+
+--
+-- Name: FUNCTION overlaps_2d(maevsi.box2df, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_2d(maevsi.box2df, maevsi.box2df) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_2d(maevsi.box2df, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_2d(maevsi.box2df, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_2d(maevsi.geometry, maevsi.box2df); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_2d(maevsi.geometry, maevsi.box2df) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_geog(maevsi.geography, maevsi.gidx); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_geog(maevsi.geography, maevsi.gidx) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_geog(maevsi.gidx, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_geog(maevsi.gidx, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_geog(maevsi.gidx, maevsi.gidx); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_geog(maevsi.gidx, maevsi.gidx) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_nd(maevsi.geometry, maevsi.gidx); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_nd(maevsi.geometry, maevsi.gidx) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_nd(maevsi.gidx, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_nd(maevsi.gidx, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION overlaps_nd(maevsi.gidx, maevsi.gidx); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.overlaps_nd(maevsi.gidx, maevsi.gidx) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asflatgeobuf_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asflatgeobuf_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asflatgeobuf_transfn(internal, anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asflatgeobuf_transfn(internal, anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asflatgeobuf_transfn(internal, anyelement, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asflatgeobuf_transfn(internal, anyelement, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asflatgeobuf_transfn(internal, anyelement, boolean, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asflatgeobuf_transfn(internal, anyelement, boolean, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asgeobuf_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asgeobuf_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asgeobuf_transfn(internal, anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asgeobuf_transfn(internal, anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asgeobuf_transfn(internal, anyelement, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asgeobuf_transfn(internal, anyelement, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_combinefn(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_combinefn(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_deserialfn(bytea, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_deserialfn(bytea, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_serialfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_serialfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_transfn(internal, anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_transfn(internal, anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_transfn(internal, anyelement, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_transfn(internal, anyelement, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_transfn(internal, anyelement, text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_transfn(internal, anyelement, text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_transfn(internal, anyelement, text, integer, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_transfn(internal, anyelement, text, integer, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_asmvt_transfn(internal, anyelement, text, integer, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_asmvt_transfn(internal, anyelement, text, integer, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_accum_transfn(internal, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_accum_transfn(internal, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_accum_transfn(internal, maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_accum_transfn(internal, maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_accum_transfn(internal, maevsi.geometry, double precision, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_accum_transfn(internal, maevsi.geometry, double precision, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_clusterintersecting_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_clusterintersecting_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_clusterwithin_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_clusterwithin_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_collect_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_collect_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_coverageunion_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_coverageunion_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_makeline_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_makeline_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_polygonize_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_polygonize_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_combinefn(internal, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_combinefn(internal, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_deserialfn(bytea, internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_deserialfn(bytea, internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_finalfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_finalfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_serialfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_serialfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_transfn(internal, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_transfn(internal, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION pgis_geometry_union_parallel_transfn(internal, maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.pgis_geometry_union_parallel_transfn(internal, maevsi.geometry, double precision) FROM PUBLIC;
 
 
 --
@@ -5781,11 +7594,3441 @@ REVOKE ALL ON FUNCTION maevsi.pgp_sym_encrypt_bytea(bytea, text, text) FROM PUBL
 
 
 --
+-- Name: FUNCTION populate_geometry_columns(use_typmod boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.populate_geometry_columns(use_typmod boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION populate_geometry_columns(tbl_oid oid, use_typmod boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.populate_geometry_columns(tbl_oid oid, use_typmod boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_addbbox(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_addbbox(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_cache_bbox(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_cache_bbox() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_constraint_dims(geomschema text, geomtable text, geomcolumn text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_constraint_dims(geomschema text, geomtable text, geomcolumn text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_constraint_srid(geomschema text, geomtable text, geomcolumn text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_constraint_srid(geomschema text, geomtable text, geomcolumn text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_constraint_type(geomschema text, geomtable text, geomcolumn text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_constraint_type(geomschema text, geomtable text, geomcolumn text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_dropbbox(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_dropbbox(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_extensions_upgrade(target_version text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_extensions_upgrade(target_version text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_full_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_full_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_geos_compiled_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_geos_compiled_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_geos_noop(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_geos_noop(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_geos_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_geos_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_getbbox(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_getbbox(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_hasbbox(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_hasbbox(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_index_supportfn(internal); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_index_supportfn(internal) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_lib_build_date(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_lib_build_date() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_lib_revision(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_lib_revision() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_lib_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_lib_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_libjson_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_libjson_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_liblwgeom_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_liblwgeom_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_libprotobuf_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_libprotobuf_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_libxml_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_libxml_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_noop(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_noop(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_proj_compiled_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_proj_compiled_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_proj_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_proj_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_scripts_build_date(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_scripts_build_date() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_scripts_installed(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_scripts_installed() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_scripts_released(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_scripts_released() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_srs(auth_name text, auth_srid text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_srs(auth_name text, auth_srid text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_srs_all(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_srs_all() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_srs_codes(auth_name text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_srs_codes(auth_name text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_srs_search(bounds maevsi.geometry, authname text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_srs_search(bounds maevsi.geometry, authname text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_svn_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_svn_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_transform_geometry(geom maevsi.geometry, text, text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_transform_geometry(geom maevsi.geometry, text, text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_transform_pipeline_geometry(geom maevsi.geometry, pipeline text, forward boolean, to_srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_transform_pipeline_geometry(geom maevsi.geometry, pipeline text, forward boolean, to_srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_type_name(geomname character varying, coord_dimension integer, use_new_name boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_type_name(geomname character varying, coord_dimension integer, use_new_name boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_typmod_dims(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_typmod_dims(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_typmod_srid(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_typmod_srid(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_typmod_type(integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_typmod_type(integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_version() FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION postgis_wagyu_version(); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.postgis_wagyu_version() FROM PUBLIC;
+
+
+--
 -- Name: FUNCTION profile_picture_set(upload_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
 --
 
 REVOKE ALL ON FUNCTION maevsi.profile_picture_set(upload_id uuid) FROM PUBLIC;
 GRANT ALL ON FUNCTION maevsi.profile_picture_set(upload_id uuid) TO maevsi_account;
+
+
+--
+-- Name: FUNCTION st_3dclosestpoint(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dclosestpoint(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3ddfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3ddfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3ddistance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3ddistance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3ddwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3ddwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dintersects(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dintersects(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dlength(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dlength(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dlineinterpolatepoint(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dlineinterpolatepoint(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dlongestline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dlongestline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dmakebox(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dmakebox(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dmaxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dmaxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dperimeter(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dperimeter(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dshortestline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dshortestline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_addmeasure(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_addmeasure(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_addpoint(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_addpoint(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_addpoint(geom1 maevsi.geometry, geom2 maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_addpoint(geom1 maevsi.geometry, geom2 maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_affine(maevsi.geometry, double precision, double precision, double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_affine(maevsi.geometry, double precision, double precision, double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_affine(maevsi.geometry, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_affine(maevsi.geometry, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_angle(line1 maevsi.geometry, line2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_angle(line1 maevsi.geometry, line2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_angle(pt1 maevsi.geometry, pt2 maevsi.geometry, pt3 maevsi.geometry, pt4 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_angle(pt1 maevsi.geometry, pt2 maevsi.geometry, pt3 maevsi.geometry, pt4 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_area(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_area(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_area(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_area(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_area(geog maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_area(geog maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_area2d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_area2d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asbinary(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asbinary(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asbinary(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asbinary(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asbinary(maevsi.geography, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asbinary(maevsi.geography, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asbinary(maevsi.geometry, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asbinary(maevsi.geometry, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asencodedpolyline(geom maevsi.geometry, nprecision integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asencodedpolyline(geom maevsi.geometry, nprecision integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkb(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkb(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkb(maevsi.geometry, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkb(maevsi.geometry, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkt(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkt(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkt(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkt(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkt(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkt(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkt(maevsi.geography, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkt(maevsi.geography, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asewkt(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asewkt(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeojson(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeojson(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeojson(geog maevsi.geography, maxdecimaldigits integer, options integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeojson(geog maevsi.geography, maxdecimaldigits integer, options integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeojson(geom maevsi.geometry, maxdecimaldigits integer, options integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeojson(geom maevsi.geometry, maxdecimaldigits integer, options integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeojson(r record, geom_column text, maxdecimaldigits integer, pretty_bool boolean, id_column text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeojson(r record, geom_column text, maxdecimaldigits integer, pretty_bool boolean, id_column text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgml(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgml(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgml(geom maevsi.geometry, maxdecimaldigits integer, options integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgml(geom maevsi.geometry, maxdecimaldigits integer, options integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgml(geog maevsi.geography, maxdecimaldigits integer, options integer, nprefix text, id text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgml(geog maevsi.geography, maxdecimaldigits integer, options integer, nprefix text, id text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgml(version integer, geog maevsi.geography, maxdecimaldigits integer, options integer, nprefix text, id text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgml(version integer, geog maevsi.geography, maxdecimaldigits integer, options integer, nprefix text, id text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgml(version integer, geom maevsi.geometry, maxdecimaldigits integer, options integer, nprefix text, id text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgml(version integer, geom maevsi.geometry, maxdecimaldigits integer, options integer, nprefix text, id text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ashexewkb(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ashexewkb(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ashexewkb(maevsi.geometry, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ashexewkb(maevsi.geometry, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_askml(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_askml(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_askml(geog maevsi.geography, maxdecimaldigits integer, nprefix text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_askml(geog maevsi.geography, maxdecimaldigits integer, nprefix text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_askml(geom maevsi.geometry, maxdecimaldigits integer, nprefix text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_askml(geom maevsi.geometry, maxdecimaldigits integer, nprefix text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_aslatlontext(geom maevsi.geometry, tmpl text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_aslatlontext(geom maevsi.geometry, tmpl text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmarc21(geom maevsi.geometry, format text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmarc21(geom maevsi.geometry, format text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvtgeom(geom maevsi.geometry, bounds maevsi.box2d, extent integer, buffer integer, clip_geom boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvtgeom(geom maevsi.geometry, bounds maevsi.box2d, extent integer, buffer integer, clip_geom boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_assvg(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_assvg(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_assvg(geog maevsi.geography, rel integer, maxdecimaldigits integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_assvg(geog maevsi.geography, rel integer, maxdecimaldigits integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_assvg(geom maevsi.geometry, rel integer, maxdecimaldigits integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_assvg(geom maevsi.geometry, rel integer, maxdecimaldigits integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astext(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astext(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astext(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astext(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astext(maevsi.geography, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astext(maevsi.geography, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astext(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astext(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astwkb(geom maevsi.geometry, prec integer, prec_z integer, prec_m integer, with_sizes boolean, with_boxes boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astwkb(geom maevsi.geometry, prec integer, prec_z integer, prec_m integer, with_sizes boolean, with_boxes boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_astwkb(geom maevsi.geometry[], ids bigint[], prec integer, prec_z integer, prec_m integer, with_sizes boolean, with_boxes boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_astwkb(geom maevsi.geometry[], ids bigint[], prec integer, prec_z integer, prec_m integer, with_sizes boolean, with_boxes boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asx3d(geom maevsi.geometry, maxdecimaldigits integer, options integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asx3d(geom maevsi.geometry, maxdecimaldigits integer, options integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_azimuth(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_azimuth(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_azimuth(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_azimuth(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_bdmpolyfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_bdmpolyfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_bdpolyfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_bdpolyfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_boundary(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_boundary(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_boundingdiagonal(geom maevsi.geometry, fits boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_boundingdiagonal(geom maevsi.geometry, fits boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_box2dfromgeohash(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_box2dfromgeohash(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(maevsi.geography, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(maevsi.geography, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(text, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(text, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(maevsi.geography, double precision, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(maevsi.geography, double precision, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(maevsi.geography, double precision, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(maevsi.geography, double precision, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(geom maevsi.geometry, radius double precision, quadsegs integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(geom maevsi.geometry, radius double precision, quadsegs integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(geom maevsi.geometry, radius double precision, options text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(geom maevsi.geometry, radius double precision, options text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(text, double precision, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(text, double precision, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buffer(text, double precision, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buffer(text, double precision, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_buildarea(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_buildarea(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_centroid(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_centroid(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_centroid(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_centroid(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_centroid(maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_centroid(maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_chaikinsmoothing(maevsi.geometry, integer, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_chaikinsmoothing(maevsi.geometry, integer, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_cleangeometry(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_cleangeometry(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clipbybox2d(geom maevsi.geometry, box maevsi.box2d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clipbybox2d(geom maevsi.geometry, box maevsi.box2d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_closestpoint(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_closestpoint(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_closestpoint(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_closestpoint(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_closestpoint(maevsi.geography, maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_closestpoint(maevsi.geography, maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_closestpointofapproach(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_closestpointofapproach(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterdbscan(maevsi.geometry, eps double precision, minpoints integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterdbscan(maevsi.geometry, eps double precision, minpoints integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterintersecting(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterintersecting(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterintersectingwin(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterintersectingwin(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterkmeans(geom maevsi.geometry, k integer, max_radius double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterkmeans(geom maevsi.geometry, k integer, max_radius double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterwithin(maevsi.geometry[], double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterwithin(maevsi.geometry[], double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterwithinwin(maevsi.geometry, distance double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterwithinwin(maevsi.geometry, distance double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collect(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collect(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collect(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collect(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collectionextract(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collectionextract(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collectionextract(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collectionextract(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collectionhomogenize(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collectionhomogenize(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_combinebbox(maevsi.box2d, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_combinebbox(maevsi.box2d, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_combinebbox(maevsi.box3d, maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_combinebbox(maevsi.box3d, maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_combinebbox(maevsi.box3d, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_combinebbox(maevsi.box3d, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_concavehull(param_geom maevsi.geometry, param_pctconvex double precision, param_allow_holes boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_concavehull(param_geom maevsi.geometry, param_pctconvex double precision, param_allow_holes boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_contains(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_contains(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_containsproperly(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_containsproperly(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_convexhull(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_convexhull(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coorddim(geometry maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coorddim(geometry maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coverageinvalidedges(geom maevsi.geometry, tolerance double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coverageinvalidedges(geom maevsi.geometry, tolerance double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coveragesimplify(geom maevsi.geometry, tolerance double precision, simplifyboundary boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coveragesimplify(geom maevsi.geometry, tolerance double precision, simplifyboundary boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coverageunion(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coverageunion(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coveredby(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coveredby(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coveredby(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coveredby(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coveredby(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coveredby(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_covers(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_covers(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_covers(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_covers(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_covers(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_covers(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_cpawithin(maevsi.geometry, maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_cpawithin(maevsi.geometry, maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_crosses(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_crosses(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_curven(geometry maevsi.geometry, i integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_curven(geometry maevsi.geometry, i integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_curvetoline(geom maevsi.geometry, tol double precision, toltype integer, flags integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_curvetoline(geom maevsi.geometry, tol double precision, toltype integer, flags integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_delaunaytriangles(g1 maevsi.geometry, tolerance double precision, flags integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_delaunaytriangles(g1 maevsi.geometry, tolerance double precision, flags integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dfullywithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_difference(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_difference(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dimension(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dimension(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_disjoint(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_disjoint(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distance(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distance(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distance(geog1 maevsi.geography, geog2 maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distance(geog1 maevsi.geography, geog2 maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distancecpa(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distancecpa(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distancesphere(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distancesphere(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distancesphere(geom1 maevsi.geometry, geom2 maevsi.geometry, radius double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distancesphere(geom1 maevsi.geometry, geom2 maevsi.geometry, radius double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distancespheroid(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distancespheroid(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_distancespheroid(geom1 maevsi.geometry, geom2 maevsi.geometry, maevsi.spheroid); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_distancespheroid(geom1 maevsi.geometry, geom2 maevsi.geometry, maevsi.spheroid) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dump(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dump(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dumppoints(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dumppoints(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dumprings(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dumprings(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dumpsegments(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dumpsegments(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dwithin(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dwithin(text, text, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dwithin(text, text, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_dwithin(geog1 maevsi.geography, geog2 maevsi.geography, tolerance double precision, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_dwithin(geog1 maevsi.geography, geog2 maevsi.geography, tolerance double precision, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_endpoint(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_endpoint(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_envelope(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_envelope(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_equals(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_equals(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_estimatedextent(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_estimatedextent(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_estimatedextent(text, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_estimatedextent(text, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_estimatedextent(text, text, text, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_estimatedextent(text, text, text, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(maevsi.box2d, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(maevsi.box2d, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(maevsi.box3d, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(maevsi.box3d, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(box maevsi.box2d, dx double precision, dy double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(box maevsi.box2d, dx double precision, dy double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(box maevsi.box3d, dx double precision, dy double precision, dz double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(box maevsi.box3d, dx double precision, dy double precision, dz double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_expand(geom maevsi.geometry, dx double precision, dy double precision, dz double precision, dm double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_expand(geom maevsi.geometry, dx double precision, dy double precision, dz double precision, dm double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_exteriorring(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_exteriorring(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_filterbym(maevsi.geometry, double precision, double precision, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_filterbym(maevsi.geometry, double precision, double precision, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_findextent(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_findextent(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_findextent(text, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_findextent(text, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_flipcoordinates(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_flipcoordinates(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_force2d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_force2d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_force3d(geom maevsi.geometry, zvalue double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_force3d(geom maevsi.geometry, zvalue double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_force3dm(geom maevsi.geometry, mvalue double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_force3dm(geom maevsi.geometry, mvalue double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_force3dz(geom maevsi.geometry, zvalue double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_force3dz(geom maevsi.geometry, zvalue double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_force4d(geom maevsi.geometry, zvalue double precision, mvalue double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_force4d(geom maevsi.geometry, zvalue double precision, mvalue double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcecollection(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcecollection(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcecurve(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcecurve(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcepolygonccw(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcepolygonccw(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcepolygoncw(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcepolygoncw(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcerhr(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcerhr(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcesfs(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcesfs(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_forcesfs(maevsi.geometry, version text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_forcesfs(maevsi.geometry, version text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_frechetdistance(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_frechetdistance(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_fromflatgeobuf(anyelement, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_fromflatgeobuf(anyelement, bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_fromflatgeobuftotable(text, text, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_fromflatgeobuftotable(text, text, bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_generatepoints(area maevsi.geometry, npoints integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_generatepoints(area maevsi.geometry, npoints integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_generatepoints(area maevsi.geometry, npoints integer, seed integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_generatepoints(area maevsi.geometry, npoints integer, seed integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geogfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geogfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geogfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geogfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geographyfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geographyfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geohash(geog maevsi.geography, maxchars integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geohash(geog maevsi.geography, maxchars integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geohash(geom maevsi.geometry, maxchars integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geohash(geom maevsi.geometry, maxchars integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomcollfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomcollfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomcollfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomcollfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomcollfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomcollfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomcollfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomcollfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geometricmedian(g maevsi.geometry, tolerance double precision, max_iter integer, fail_if_not_converged boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geometricmedian(g maevsi.geometry, tolerance double precision, max_iter integer, fail_if_not_converged boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geometryfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geometryfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geometryfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geometryfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geometryn(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geometryn(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geometrytype(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geometrytype(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromewkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromewkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromewkt(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromewkt(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgeohash(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgeohash(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgeojson(json); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgeojson(json) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgeojson(jsonb); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgeojson(jsonb) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgeojson(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgeojson(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgml(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgml(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromgml(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromgml(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromkml(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromkml(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfrommarc21(marc21xml text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfrommarc21(marc21xml text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromtwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromtwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_geomfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_geomfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_gmltosql(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_gmltosql(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_gmltosql(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_gmltosql(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hasarc(geometry maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hasarc(geometry maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hasm(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hasm(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hasz(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hasz(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hausdorffdistance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hausdorffdistance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hausdorffdistance(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hausdorffdistance(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hexagon(size double precision, cell_i integer, cell_j integer, origin maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hexagon(size double precision, cell_i integer, cell_j integer, origin maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_hexagongrid(size double precision, bounds maevsi.geometry, OUT geom maevsi.geometry, OUT i integer, OUT j integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_hexagongrid(size double precision, bounds maevsi.geometry, OUT geom maevsi.geometry, OUT i integer, OUT j integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_interiorringn(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_interiorringn(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_interpolatepoint(line maevsi.geometry, point maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_interpolatepoint(line maevsi.geometry, point maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersection(maevsi.geography, maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersection(maevsi.geography, maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersection(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersection(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersection(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersection(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersects(geog1 maevsi.geography, geog2 maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersects(geog1 maevsi.geography, geog2 maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersects(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersects(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_intersects(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_intersects(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_inversetransformpipeline(geom maevsi.geometry, pipeline text, to_srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_inversetransformpipeline(geom maevsi.geometry, pipeline text, to_srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isclosed(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isclosed(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_iscollection(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_iscollection(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isempty(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isempty(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ispolygonccw(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ispolygonccw(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ispolygoncw(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ispolygoncw(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isring(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isring(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_issimple(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_issimple(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvalid(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvalid(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvalid(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvalid(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvaliddetail(geom maevsi.geometry, flags integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvaliddetail(geom maevsi.geometry, flags integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvalidreason(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvalidreason(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvalidreason(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvalidreason(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_isvalidtrajectory(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_isvalidtrajectory(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_largestemptycircle(geom maevsi.geometry, tolerance double precision, boundary maevsi.geometry, OUT center maevsi.geometry, OUT nearest maevsi.geometry, OUT radius double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_largestemptycircle(geom maevsi.geometry, tolerance double precision, boundary maevsi.geometry, OUT center maevsi.geometry, OUT nearest maevsi.geometry, OUT radius double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_length(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_length(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_length(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_length(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_length(geog maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_length(geog maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_length2d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_length2d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_length2dspheroid(maevsi.geometry, maevsi.spheroid); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_length2dspheroid(maevsi.geometry, maevsi.spheroid) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lengthspheroid(maevsi.geometry, maevsi.spheroid); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lengthspheroid(maevsi.geometry, maevsi.spheroid) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_letters(letters text, font json); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_letters(letters text, font json) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linecrossingdirection(line1 maevsi.geometry, line2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linecrossingdirection(line1 maevsi.geometry, line2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineextend(geom maevsi.geometry, distance_forward double precision, distance_backward double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineextend(geom maevsi.geometry, distance_forward double precision, distance_backward double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefromencodedpolyline(txtin text, nprecision integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefromencodedpolyline(txtin text, nprecision integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefrommultipoint(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefrommultipoint(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linefromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linefromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoint(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoint(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoint(text, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoint(text, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoint(maevsi.geography, double precision, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoint(maevsi.geography, double precision, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoints(text, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoints(text, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoints(maevsi.geometry, double precision, repeat boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoints(maevsi.geometry, double precision, repeat boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_lineinterpolatepoints(maevsi.geography, double precision, use_spheroid boolean, repeat boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_lineinterpolatepoints(maevsi.geography, double precision, use_spheroid boolean, repeat boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linelocatepoint(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linelocatepoint(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linelocatepoint(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linelocatepoint(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linelocatepoint(maevsi.geography, maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linelocatepoint(maevsi.geography, maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linemerge(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linemerge(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linemerge(maevsi.geometry, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linemerge(maevsi.geometry, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linestringfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linestringfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linestringfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linestringfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linesubstring(maevsi.geography, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linesubstring(maevsi.geography, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linesubstring(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linesubstring(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linesubstring(text, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linesubstring(text, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_linetocurve(geometry maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_linetocurve(geometry maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_locatealong(geometry maevsi.geometry, measure double precision, leftrightoffset double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_locatealong(geometry maevsi.geometry, measure double precision, leftrightoffset double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_locatebetween(geometry maevsi.geometry, frommeasure double precision, tomeasure double precision, leftrightoffset double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_locatebetween(geometry maevsi.geometry, frommeasure double precision, tomeasure double precision, leftrightoffset double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_locatebetweenelevations(geometry maevsi.geometry, fromelevation double precision, toelevation double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_locatebetweenelevations(geometry maevsi.geometry, fromelevation double precision, toelevation double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_longestline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_longestline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_m(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_m(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makebox2d(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makebox2d(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makeenvelope(double precision, double precision, double precision, double precision, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makeenvelope(double precision, double precision, double precision, double precision, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makeline(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makeline(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makeline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makeline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepoint(double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepoint(double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepoint(double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepoint(double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepoint(double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepoint(double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepointm(double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepointm(double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepolygon(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepolygon(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makepolygon(maevsi.geometry, maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makepolygon(maevsi.geometry, maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makevalid(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makevalid(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makevalid(geom maevsi.geometry, params text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makevalid(geom maevsi.geometry, params text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_maxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_maxdistance(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_maximuminscribedcircle(maevsi.geometry, OUT center maevsi.geometry, OUT nearest maevsi.geometry, OUT radius double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_maximuminscribedcircle(maevsi.geometry, OUT center maevsi.geometry, OUT nearest maevsi.geometry, OUT radius double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_memsize(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_memsize(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_minimumboundingcircle(inputgeom maevsi.geometry, segs_per_quarter integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_minimumboundingcircle(inputgeom maevsi.geometry, segs_per_quarter integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_minimumboundingradius(maevsi.geometry, OUT center maevsi.geometry, OUT radius double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_minimumboundingradius(maevsi.geometry, OUT center maevsi.geometry, OUT radius double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_minimumclearance(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_minimumclearance(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_minimumclearanceline(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_minimumclearanceline(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mlinefromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mlinefromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mlinefromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mlinefromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mlinefromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mlinefromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mlinefromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mlinefromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpointfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpointfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpointfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpointfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpointfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpointfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpointfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpointfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpolyfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpolyfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpolyfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpolyfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpolyfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpolyfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_mpolyfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_mpolyfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multi(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multi(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multilinefromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multilinefromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multilinestringfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multilinestringfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multilinestringfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multilinestringfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipointfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipointfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipointfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipointfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipointfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipointfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipolyfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipolyfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipolyfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipolyfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipolygonfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipolygonfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_multipolygonfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_multipolygonfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ndims(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ndims(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_node(g maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_node(g maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_normalize(geom maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_normalize(geom maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_npoints(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_npoints(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_nrings(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_nrings(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numcurves(geometry maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numcurves(geometry maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numgeometries(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numgeometries(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numinteriorring(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numinteriorring(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numinteriorrings(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numinteriorrings(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numpatches(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numpatches(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_numpoints(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_numpoints(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_offsetcurve(line maevsi.geometry, distance double precision, params text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_offsetcurve(line maevsi.geometry, distance double precision, params text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_orderingequals(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_orderingequals(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_orientedenvelope(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_orientedenvelope(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_overlaps(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_patchn(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_patchn(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_perimeter(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_perimeter(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_perimeter(geog maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_perimeter(geog maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_perimeter2d(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_perimeter2d(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_point(double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_point(double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_point(double precision, double precision, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_point(double precision, double precision, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointfromgeohash(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointfromgeohash(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointinsidecircle(maevsi.geometry, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointinsidecircle(maevsi.geometry, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointm(xcoordinate double precision, ycoordinate double precision, mcoordinate double precision, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointm(xcoordinate double precision, ycoordinate double precision, mcoordinate double precision, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointn(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointn(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointonsurface(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointonsurface(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_points(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_points(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointz(xcoordinate double precision, ycoordinate double precision, zcoordinate double precision, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointz(xcoordinate double precision, ycoordinate double precision, zcoordinate double precision, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_pointzm(xcoordinate double precision, ycoordinate double precision, zcoordinate double precision, mcoordinate double precision, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_pointzm(xcoordinate double precision, ycoordinate double precision, zcoordinate double precision, mcoordinate double precision, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polyfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polyfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polyfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polyfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polyfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polyfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polyfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polyfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygon(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygon(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonfromtext(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonfromtext(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonfromtext(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonfromtext(text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonfromwkb(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonfromwkb(bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonfromwkb(bytea, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonfromwkb(bytea, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonize(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonize(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_project(geog_from maevsi.geography, geog_to maevsi.geography, distance double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_project(geog_from maevsi.geography, geog_to maevsi.geography, distance double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_project(geog maevsi.geography, distance double precision, azimuth double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_project(geog maevsi.geography, distance double precision, azimuth double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_project(geom1 maevsi.geometry, geom2 maevsi.geometry, distance double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_project(geom1 maevsi.geometry, geom2 maevsi.geometry, distance double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_project(geom1 maevsi.geometry, distance double precision, azimuth double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_project(geom1 maevsi.geometry, distance double precision, azimuth double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_quantizecoordinates(g maevsi.geometry, prec_x integer, prec_y integer, prec_z integer, prec_m integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_quantizecoordinates(g maevsi.geometry, prec_x integer, prec_y integer, prec_z integer, prec_m integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_reduceprecision(geom maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_reduceprecision(geom maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_relate(geom1 maevsi.geometry, geom2 maevsi.geometry, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_relatematch(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_relatematch(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_removeirrelevantpointsforview(maevsi.geometry, maevsi.box2d, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_removeirrelevantpointsforview(maevsi.geometry, maevsi.box2d, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_removepoint(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_removepoint(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_removerepeatedpoints(geom maevsi.geometry, tolerance double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_removerepeatedpoints(geom maevsi.geometry, tolerance double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_removesmallparts(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_removesmallparts(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_reverse(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_reverse(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotate(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotate(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotate(maevsi.geometry, double precision, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotate(maevsi.geometry, double precision, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotate(maevsi.geometry, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotate(maevsi.geometry, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotatex(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotatex(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotatey(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotatey(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_rotatez(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_rotatez(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_scale(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_scale(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_scale(maevsi.geometry, maevsi.geometry, origin maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_scale(maevsi.geometry, maevsi.geometry, origin maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_scale(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_scale(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_scale(maevsi.geometry, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_scale(maevsi.geometry, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_scroll(maevsi.geometry, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_scroll(maevsi.geometry, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_segmentize(geog maevsi.geography, max_segment_length double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_segmentize(geog maevsi.geography, max_segment_length double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_segmentize(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_segmentize(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_seteffectivearea(maevsi.geometry, double precision, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_seteffectivearea(maevsi.geometry, double precision, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_setpoint(maevsi.geometry, integer, maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_setpoint(maevsi.geometry, integer, maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_setsrid(geog maevsi.geography, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_setsrid(geog maevsi.geography, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_setsrid(geom maevsi.geometry, srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_setsrid(geom maevsi.geometry, srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_sharedpaths(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_sharedpaths(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_shiftlongitude(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_shiftlongitude(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_shortestline(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_shortestline(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_shortestline(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_shortestline(text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_shortestline(maevsi.geography, maevsi.geography, use_spheroid boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_shortestline(maevsi.geography, maevsi.geography, use_spheroid boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_simplify(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_simplify(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_simplify(maevsi.geometry, double precision, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_simplify(maevsi.geometry, double precision, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_simplifypolygonhull(geom maevsi.geometry, vertex_fraction double precision, is_outer boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_simplifypolygonhull(geom maevsi.geometry, vertex_fraction double precision, is_outer boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_simplifypreservetopology(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_simplifypreservetopology(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_simplifyvw(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_simplifyvw(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_snap(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_snap(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_snaptogrid(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_snaptogrid(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_snaptogrid(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_snaptogrid(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_snaptogrid(maevsi.geometry, double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_snaptogrid(maevsi.geometry, double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_snaptogrid(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_snaptogrid(geom1 maevsi.geometry, geom2 maevsi.geometry, double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_split(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_split(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_square(size double precision, cell_i integer, cell_j integer, origin maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_square(size double precision, cell_i integer, cell_j integer, origin maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_squaregrid(size double precision, bounds maevsi.geometry, OUT geom maevsi.geometry, OUT i integer, OUT j integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_squaregrid(size double precision, bounds maevsi.geometry, OUT geom maevsi.geometry, OUT i integer, OUT j integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_srid(geog maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_srid(geog maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_srid(geom maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_srid(geom maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_startpoint(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_startpoint(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_subdivide(geom maevsi.geometry, maxvertices integer, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_subdivide(geom maevsi.geometry, maxvertices integer, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_summary(maevsi.geography); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_summary(maevsi.geography) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_summary(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_summary(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_swapordinates(geom maevsi.geometry, ords cstring); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_swapordinates(geom maevsi.geometry, ords cstring) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_symdifference(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_symdifference(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_symmetricdifference(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_symmetricdifference(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_tileenvelope(zoom integer, x integer, y integer, bounds maevsi.geometry, margin double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_tileenvelope(zoom integer, x integer, y integer, bounds maevsi.geometry, margin double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_touches(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_touches(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transform(maevsi.geometry, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transform(maevsi.geometry, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transform(geom maevsi.geometry, to_proj text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transform(geom maevsi.geometry, to_proj text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transform(geom maevsi.geometry, from_proj text, to_srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transform(geom maevsi.geometry, from_proj text, to_srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transform(geom maevsi.geometry, from_proj text, to_proj text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transform(geom maevsi.geometry, from_proj text, to_proj text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transformpipeline(geom maevsi.geometry, pipeline text, to_srid integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transformpipeline(geom maevsi.geometry, pipeline text, to_srid integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_translate(maevsi.geometry, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_translate(maevsi.geometry, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_translate(maevsi.geometry, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_translate(maevsi.geometry, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_transscale(maevsi.geometry, double precision, double precision, double precision, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_transscale(maevsi.geometry, double precision, double precision, double precision, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_triangulatepolygon(g1 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_triangulatepolygon(g1 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_unaryunion(maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_unaryunion(maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_union(maevsi.geometry[]); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_union(maevsi.geometry[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_union(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_union(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_union(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_union(geom1 maevsi.geometry, geom2 maevsi.geometry, gridsize double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_voronoilines(g1 maevsi.geometry, tolerance double precision, extend_to maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_voronoilines(g1 maevsi.geometry, tolerance double precision, extend_to maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_voronoipolygons(g1 maevsi.geometry, tolerance double precision, extend_to maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_voronoipolygons(g1 maevsi.geometry, tolerance double precision, extend_to maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_within(geom1 maevsi.geometry, geom2 maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_within(geom1 maevsi.geometry, geom2 maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_wkbtosql(wkb bytea); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_wkbtosql(wkb bytea) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_wkttosql(text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_wkttosql(text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_wrapx(geom maevsi.geometry, wrap double precision, move double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_wrapx(geom maevsi.geometry, wrap double precision, move double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_x(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_x(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_xmax(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_xmax(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_xmin(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_xmin(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_y(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_y(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ymax(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ymax(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_ymin(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_ymin(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_z(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_z(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_zmax(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_zmax(maevsi.box3d) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_zmflag(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_zmflag(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_zmin(maevsi.box3d); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_zmin(maevsi.box3d) FROM PUBLIC;
 
 
 --
@@ -5803,6 +11046,27 @@ GRANT ALL ON FUNCTION maevsi.trigger_contact_update_account_id() TO maevsi_accou
 REVOKE ALL ON FUNCTION maevsi.trigger_invitation_update() FROM PUBLIC;
 GRANT ALL ON FUNCTION maevsi.trigger_invitation_update() TO maevsi_account;
 GRANT ALL ON FUNCTION maevsi.trigger_invitation_update() TO maevsi_anonymous;
+
+
+--
+-- Name: FUNCTION updategeometrysrid(character varying, character varying, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.updategeometrysrid(character varying, character varying, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION updategeometrysrid(character varying, character varying, character varying, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.updategeometrysrid(character varying, character varying, character varying, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION updategeometrysrid(catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.updategeometrysrid(catalogn_name character varying, schema_name character varying, table_name character varying, column_name character varying, new_srid_in integer) FROM PUBLIC;
 
 
 --
@@ -5943,6 +11207,160 @@ REVOKE ALL ON FUNCTION maevsi_test.invitation_create(_author_account_id uuid, _e
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_3dextent(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_3dextent(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asflatgeobuf(anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asflatgeobuf(anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asflatgeobuf(anyelement, boolean); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asflatgeobuf(anyelement, boolean) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asflatgeobuf(anyelement, boolean, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asflatgeobuf(anyelement, boolean, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeobuf(anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeobuf(anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asgeobuf(anyelement, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asgeobuf(anyelement, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvt(anyelement); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvt(anyelement) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvt(anyelement, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvt(anyelement, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvt(anyelement, text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvt(anyelement, text, integer) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvt(anyelement, text, integer, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvt(anyelement, text, integer, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_asmvt(anyelement, text, integer, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_asmvt(anyelement, text, integer, text, text) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterintersecting(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterintersecting(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_clusterwithin(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_clusterwithin(maevsi.geometry, double precision) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_collect(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_collect(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_coverageunion(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_coverageunion(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_extent(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_extent(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_makeline(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_makeline(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_memcollect(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_memcollect(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_memunion(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_memunion(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_polygonize(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_polygonize(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_union(maevsi.geometry); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_union(maevsi.geometry) FROM PUBLIC;
+
+
+--
+-- Name: FUNCTION st_union(maevsi.geometry, double precision); Type: ACL; Schema: maevsi; Owner: postgres
+--
+
+REVOKE ALL ON FUNCTION maevsi.st_union(maevsi.geometry, double precision) FROM PUBLIC;
 
 
 --


### PR DESCRIPTION
Here we go, enabling PostGIS support for maevsi's database. It appears that PostGIS functions and tables are not shown in Postgraphile. This is a breaking change as it requires the Debezium PostgreSQL container version in `maevsi_stack` to change to the non-alpine variant which has PostGIS bundled.