### PR TITLE
ci: filter out drafts from job optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: 8BitJonny/gh-get-current-pr@3.0.0
         with:
           filterOutClosed: true
+          filterOutDraft: true
           sha: ${{ github.event.pull_request.head.sha }}
   release_semantic_dry:
     needs: prepare_jobs


### PR DESCRIPTION
Right now there are no new beta releases created because there is already a PR for merging the `beta` branch into `master` and the optimization job skips workflow runs in that case. I think filtering out draft PRs would be a plausible fix.