### PR TITLE
fix(location): move test function to appropriate schema

### DIFF
--- a/src/deploy/schema_test.sql
+++ b/src/deploy/schema_test.sql
@@ -4,4 +4,6 @@ CREATE SCHEMA maevsi_test;
 
 COMMENT ON SCHEMA maevsi_test IS 'Schema for test functions.';
 
+GRANT USAGE ON SCHEMA maevsi_test TO maevsi_anonymous, maevsi_account;
+
 COMMIT;

--- a/src/deploy/test_location.sql
+++ b/src/deploy/test_location.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 
-CREATE FUNCTION maevsi.account_filter_radius_event(
+CREATE FUNCTION maevsi_test.account_filter_radius_event(
   _event_id UUID,
   _distance_max DOUBLE PRECISION
 )
@@ -27,12 +27,12 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT STABLE SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.account_filter_radius_event(UUID, DOUBLE PRECISION) IS 'Returns account locations within a given radius around the location of an event.';
+COMMENT ON FUNCTION maevsi_test.account_filter_radius_event(UUID, DOUBLE PRECISION) IS 'Returns account locations within a given radius around the location of an event.';
 
-GRANT EXECUTE ON FUNCTION maevsi.account_filter_radius_event(UUID, DOUBLE PRECISION) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.account_filter_radius_event(UUID, DOUBLE PRECISION) TO maevsi_account;
 
 
-CREATE FUNCTION maevsi.event_filter_radius_account(
+CREATE FUNCTION maevsi_test.event_filter_radius_account(
   _account_id UUID,
   _distance_max DOUBLE PRECISION
 )
@@ -58,12 +58,12 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT STABLE SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.event_filter_radius_account(UUID, DOUBLE PRECISION) IS  'Returns event locations within a given radius around the location of an account.';
+COMMENT ON FUNCTION maevsi_test.event_filter_radius_account(UUID, DOUBLE PRECISION) IS  'Returns event locations within a given radius around the location of an account.';
 
-GRANT EXECUTE ON FUNCTION maevsi.event_filter_radius_account(UUID, DOUBLE PRECISION) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.event_filter_radius_account(UUID, DOUBLE PRECISION) TO maevsi_account;
 
 
-CREATE FUNCTION maevsi.account_location_update(
+CREATE FUNCTION maevsi_test.account_location_update(
   _account_id UUID,
   _latitude DOUBLE PRECISION,
   _longitude DOUBLE PRECISION
@@ -78,12 +78,12 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) IS 'Updates an account''s location based on latitude and longitude (GPS coordinates).';
+COMMENT ON FUNCTION maevsi_test.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) IS 'Updates an account''s location based on latitude and longitude (GPS coordinates).';
 
-GRANT EXECUTE ON FUNCTION maevsi.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) TO maevsi_account;
 
 
-CREATE FUNCTION maevsi.event_location_update(
+CREATE FUNCTION maevsi_test.event_location_update(
   _event_id UUID,
   _latitude DOUBLE PRECISION,
   _longitude DOUBLE PRECISION
@@ -98,12 +98,12 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) IS 'Updates an event''s location based on latitude and longitude (GPS coordinates).';
+COMMENT ON FUNCTION maevsi_test.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) IS 'Updates an event''s location based on latitude and longitude (GPS coordinates).';
 
-GRANT EXECUTE ON FUNCTION maevsi.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION) TO maevsi_account;
 
 
-CREATE FUNCTION maevsi.account_location_coordinates(
+CREATE FUNCTION maevsi_test.account_location_coordinates(
   _account_id UUID
 )
 RETURNS DOUBLE PRECISION[] AS $$
@@ -126,12 +126,12 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT STABLE SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.account_location_coordinates(UUID) IS 'Returns an array with latitude and longitude of the account''s current location data';
+COMMENT ON FUNCTION maevsi_test.account_location_coordinates(UUID) IS 'Returns an array with latitude and longitude of the account''s current location data';
 
-GRANT EXECUTE ON FUNCTION maevsi.account_location_coordinates(UUID) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.account_location_coordinates(UUID) TO maevsi_account;
 
 
-CREATE FUNCTION maevsi.event_location_coordinates(
+CREATE FUNCTION maevsi_test.event_location_coordinates(
   _event_id UUID
 )
 RETURNS DOUBLE PRECISION[] AS $$
@@ -154,9 +154,9 @@ BEGIN
 END;
 $$ LANGUAGE PLPGSQL STRICT STABLE SECURITY DEFINER;
 
-COMMENT ON FUNCTION maevsi.event_location_coordinates(UUID) IS 'Returns an array with latitude and longitude of the event''s current location data.';
+COMMENT ON FUNCTION maevsi_test.event_location_coordinates(UUID) IS 'Returns an array with latitude and longitude of the event''s current location data.';
 
-GRANT EXECUTE ON FUNCTION maevsi.event_location_coordinates(UUID) TO maevsi_account;
+GRANT EXECUTE ON FUNCTION maevsi_test.event_location_coordinates(UUID) TO maevsi_account;
 
 
 COMMIT;

--- a/src/revert/test_location.sql
+++ b/src/revert/test_location.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-DROP FUNCTION maevsi.account_filter_radius_event(UUID, DOUBLE PRECISION);
-DROP FUNCTION maevsi.event_filter_radius_account(UUID, DOUBLE PRECISION);
+DROP FUNCTION maevsi_test.account_filter_radius_event(UUID, DOUBLE PRECISION);
+DROP FUNCTION maevsi_test.event_filter_radius_account(UUID, DOUBLE PRECISION);
 
-DROP FUNCTION maevsi.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION);
-DROP FUNCTION maevsi.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION);
+DROP FUNCTION maevsi_test.account_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION);
+DROP FUNCTION maevsi_test.event_location_update(UUID, DOUBLE PRECISION, DOUBLE PRECISION);
 
-DROP FUNCTION maevsi.account_location_coordinates(UUID);
-DROP FUNCTION maevsi.event_location_coordinates(UUID);
+DROP FUNCTION maevsi_test.account_location_coordinates(UUID);
+DROP FUNCTION maevsi_test.event_location_coordinates(UUID);
 
 COMMIT;

--- a/src/verify/schema_public.sql
+++ b/src/verify/schema_public.sql
@@ -4,6 +4,7 @@ DO $$
 BEGIN
   ASSERT (SELECT pg_catalog.has_schema_privilege('maevsi_account', 'maevsi', 'USAGE'));
   ASSERT (SELECT pg_catalog.has_schema_privilege('maevsi_anonymous', 'maevsi', 'USAGE'));
+  ASSERT (SELECT pg_catalog.has_schema_privilege('maevsi_tusd', 'maevsi', 'USAGE'));
 END $$;
 
 ROLLBACK;

--- a/src/verify/schema_test.sql
+++ b/src/verify/schema_test.sql
@@ -5,4 +5,10 @@ BEGIN
   ASSERT EXISTS(SELECT * FROM pg_catalog.pg_namespace WHERE nspname = 'maevsi_test');
 END $$;
 
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_schema_privilege('maevsi_account', 'maevsi_test', 'USAGE'));
+  ASSERT (SELECT pg_catalog.has_schema_privilege('maevsi_anonymous', 'maevsi_test', 'USAGE'));
+END $$;
+
 ROLLBACK;

--- a/src/verify/test_location.sql
+++ b/src/verify/test_location.sql
@@ -23,16 +23,16 @@ BEGIN
   RETURNING id INTO _event_id;
 
   -- Update and validate account location
-  PERFORM maevsi.account_location_update(_account_id, 51.304, 9.476); -- Somewhere in Kassel
-  _coordinates := maevsi.account_location_coordinates(_account_id);
+  PERFORM maevsi_test.account_location_update(_account_id, 51.304, 9.476); -- Somewhere in Kassel
+  _coordinates := maevsi_test.account_location_coordinates(_account_id);
 
   IF NOT (round(_coordinates[1]::numeric, 3) = 51.304 AND round(_coordinates[2]::numeric, 3) = 9.476) THEN
     RAISE EXCEPTION 'Wrong account coordinates';
   END IF;
 
   -- Update and validate event location
-  PERFORM maevsi.event_location_update(_event_id, 50.113, 8.650); -- Somewhere in Frankfurt
-  _coordinates := maevsi.event_location_coordinates(_event_id);
+  PERFORM maevsi_test.event_location_update(_event_id, 50.113, 8.650); -- Somewhere in Frankfurt
+  _coordinates := maevsi_test.event_location_coordinates(_event_id);
 
   IF NOT (round(_coordinates[1]::numeric, 3) = 50.113 AND round(_coordinates[2]::numeric, 3) = 8.650) THEN
     RAISE EXCEPTION 'Wrong event coordinates';
@@ -40,14 +40,14 @@ BEGIN
 
   -- Test event filtering by radius from account
   SELECT event_id INTO _id
-  FROM maevsi.maevsi.event_filter_radius_account(_account_id, 100);
+  FROM maevsi_test.event_filter_radius_account(_account_id, 100);
 
   IF _id IS NOT NULL THEN
     RAISE EXCEPTION 'Function `event_filter_radius_account` with radius 100 km should have returned an empty result';
   END IF;
 
   SELECT event_id INTO _id
-  FROM maevsi.maevsi.event_filter_radius_account(_account_id, 250);
+  FROM maevsi_test.event_filter_radius_account(_account_id, 250);
 
   IF _id != _event_id THEN
     RAISE EXCEPTION 'Function `event_filter_radius_account` with radius 250 km should have returned `_event_id`';
@@ -55,14 +55,14 @@ BEGIN
 
   -- Test account filtering by radius from event
   SELECT account_id INTO _id
-  FROM maevsi.maevsi.account_filter_radius_event(_event_id, 100);
+  FROM maevsi_test.account_filter_radius_event(_event_id, 100);
 
   IF _id IS NOT NULL THEN
     RAISE EXCEPTION 'Function `account_filter_radius_event` with radius 100 km should have returned an empty result';
   END IF;
 
   SELECT account_id INTO _id
-  FROM maevsi.maevsi.account_filter_radius_event(_event_id, 250);
+  FROM maevsi_test.account_filter_radius_event(_event_id, 250);
 
   IF _id != _account_id THEN
     RAISE EXCEPTION 'Function `account_filter_radius_event` with radius 250 km should have returned `_account_id`';


### PR DESCRIPTION
If some of there functions will be used as a feature eventually, they can get dragged back out of the test schema again. I just don't want to inflate the api surface with endpoints that are not actually in use besides testing.