### PR TITLE
perf(event): early return search trigger function

### DIFF
--- a/src/deploy/table_event.sql
+++ b/src/deploy/table_event.sql
@@ -50,10 +50,19 @@ CREATE FUNCTION maevsi.trigger_event_search_vector() RETURNS TRIGGER AS $$
 DECLARE
   ts_config regconfig;
 BEGIN
+  IF NOT (
+    NEW.name IS DISTINCT FROM OLD.name OR
+    NEW.description IS DISTINCT FROM OLD.description OR
+    NEW.language IS DISTINCT FROM OLD.language
+  )
+  THEN
+    RETURN NEW;
+  END IF;
+
   ts_config := maevsi.language_iso_full_text_search(NEW.language);
 
   NEW.search_vector :=
-    setweight(to_tsvector(ts_config, coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector(ts_config, NEW.name), 'A') ||
     setweight(to_tsvector(ts_config, coalesce(NEW.description, '')), 'B');
 
   RETURN NEW;

--- a/src/deploy/table_event.sql
+++ b/src/deploy/table_event.sql
@@ -50,15 +50,6 @@ CREATE FUNCTION maevsi.trigger_event_search_vector() RETURNS TRIGGER AS $$
 DECLARE
   ts_config regconfig;
 BEGIN
-  IF NOT (
-    NEW.name IS DISTINCT FROM OLD.name OR
-    NEW.description IS DISTINCT FROM OLD.description OR
-    NEW.language IS DISTINCT FROM OLD.language
-  )
-  THEN
-    RETURN NEW;
-  END IF;
-
   ts_config := maevsi.language_iso_full_text_search(NEW.language);
 
   NEW.search_vector :=
@@ -76,7 +67,7 @@ GRANT EXECUTE ON FUNCTION maevsi.trigger_event_search_vector() TO maevsi_account
 CREATE TRIGGER maevsi_trigger_event_search_vector
   BEFORE
        INSERT
-    OR UPDATE
+    OR UPDATE OF name, description, language
   ON maevsi.event
   FOR EACH ROW
   EXECUTE FUNCTION maevsi.trigger_event_search_vector();

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -1595,15 +1595,6 @@ CREATE FUNCTION maevsi.trigger_event_search_vector() RETURNS trigger
 DECLARE
   ts_config regconfig;
 BEGIN
-  IF NOT (
-    NEW.name IS DISTINCT FROM OLD.name OR
-    NEW.description IS DISTINCT FROM OLD.description OR
-    NEW.language IS DISTINCT FROM OLD.language
-  )
-  THEN
-    RETURN NEW;
-  END IF;
-
   ts_config := maevsi.language_iso_full_text_search(NEW.language);
 
   NEW.search_vector :=
@@ -4919,7 +4910,7 @@ CREATE TRIGGER maevsi_trigger_contact_update_account_id BEFORE UPDATE OF account
 -- Name: event maevsi_trigger_event_search_vector; Type: TRIGGER; Schema: maevsi; Owner: postgres
 --
 
-CREATE TRIGGER maevsi_trigger_event_search_vector BEFORE INSERT OR UPDATE ON maevsi.event FOR EACH ROW EXECUTE FUNCTION maevsi.trigger_event_search_vector();
+CREATE TRIGGER maevsi_trigger_event_search_vector BEFORE INSERT OR UPDATE OF name, description, language ON maevsi.event FOR EACH ROW EXECUTE FUNCTION maevsi.trigger_event_search_vector();
 
 
 --

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -1595,10 +1595,19 @@ CREATE FUNCTION maevsi.trigger_event_search_vector() RETURNS trigger
 DECLARE
   ts_config regconfig;
 BEGIN
+  IF NOT (
+    NEW.name IS DISTINCT FROM OLD.name OR
+    NEW.description IS DISTINCT FROM OLD.description OR
+    NEW.language IS DISTINCT FROM OLD.language
+  )
+  THEN
+    RETURN NEW;
+  END IF;
+
   ts_config := maevsi.language_iso_full_text_search(NEW.language);
 
   NEW.search_vector :=
-    setweight(to_tsvector(ts_config, coalesce(NEW.name, '')), 'A') ||
+    setweight(to_tsvector(ts_config, NEW.name), 'A') ||
     setweight(to_tsvector(ts_config, coalesce(NEW.description, '')), 'B');
 
   RETURN NEW;


### PR DESCRIPTION
Based on your [comment](https://github.com/maevsi/sqitch/pull/121/files#r1929843799), @sthelemann, I removed the `coalesce` for `name` and also added an early return if no column is changed that would result in an update on the search vector.