### PR TITLE
refactor(function): use parameter names

### DIFF
--- a/src/deploy/function_account_delete.sql
+++ b/src/deploy/function_account_delete.sql
@@ -1,14 +1,14 @@
 BEGIN;
 
 CREATE FUNCTION maevsi.account_delete(
-  "password" TEXT
+  password TEXT
 ) RETURNS VOID AS $$
 DECLARE
   _current_account_id UUID;
 BEGIN
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($1, account.password_hash))) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(account_delete.password, account.password_hash))) THEN
     IF (EXISTS (SELECT 1 FROM maevsi.event WHERE event.created_by = _current_account_id)) THEN
       RAISE 'You still own events!' USING ERRCODE = 'foreign_key_violation';
     ELSE

--- a/src/deploy/function_account_email_address_verification.sql
+++ b/src/deploy/function_account_email_address_verification.sql
@@ -9,7 +9,7 @@ BEGIN
   SELECT *
     FROM maevsi_private.account
     INTO _account
-    WHERE account.email_address_verification = $1;
+    WHERE account.email_address_verification = account_email_address_verification.code;
 
   IF (_account IS NULL) THEN
     RAISE 'Unknown verification code!' USING ERRCODE = 'no_data_found';
@@ -21,7 +21,7 @@ BEGIN
 
   UPDATE maevsi_private.account
     SET email_address_verification = NULL
-    WHERE email_address_verification = $1;
+    WHERE email_address_verification = account_email_address_verification.code;
 END;
 $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER;
 

--- a/src/deploy/function_account_password_change.sql
+++ b/src/deploy/function_account_password_change.sql
@@ -7,14 +7,14 @@ CREATE FUNCTION maevsi.account_password_change(
 DECLARE
   _current_account_id UUID;
 BEGIN
-  IF (char_length($2) < 8) THEN
+  IF (char_length(account_password_change.password_new) < 8) THEN
       RAISE 'New password too short!' USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($1, account.password_hash))) THEN
-    UPDATE maevsi_private.account SET password_hash = crypt($2, gen_salt('bf')) WHERE account.id = _current_account_id;
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(account_password_change.password_current, account.password_hash))) THEN
+    UPDATE maevsi_private.account SET password_hash = crypt(account_password_change.password_new, gen_salt('bf')) WHERE account.id = _current_account_id;
   ELSE
     RAISE 'Account with given password not found!' USING ERRCODE = 'invalid_password';
   END IF;

--- a/src/deploy/function_account_password_reset.sql
+++ b/src/deploy/function_account_password_reset.sql
@@ -2,19 +2,19 @@ BEGIN;
 
 CREATE FUNCTION maevsi.account_password_reset(
   code UUID,
-  "password" TEXT
+  password TEXT
 ) RETURNS VOID AS $$
 DECLARE
   _account maevsi_private.account;
 BEGIN
-  IF (char_length($2) < 8) THEN
+  IF (char_length(account_password_reset.password) < 8) THEN
     RAISE 'Password too short!' USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
   SELECT *
     FROM maevsi_private.account
     INTO _account
-    WHERE account.password_reset_verification = $1;
+    WHERE account.password_reset_verification = account_password_reset.code;
 
   IF (_account IS NULL) THEN
     RAISE 'Unknown reset code!' USING ERRCODE = 'no_data_found';
@@ -26,9 +26,9 @@ BEGIN
 
   UPDATE maevsi_private.account
     SET
-      password_hash = crypt($2, gen_salt('bf')),
+      password_hash = crypt(account_password_reset.password, gen_salt('bf')),
       password_reset_verification = NULL
-    WHERE account.password_reset_verification = $1;
+    WHERE account.password_reset_verification = account_password_reset.code;
 END;
 $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER;
 

--- a/src/deploy/function_account_password_reset_request.sql
+++ b/src/deploy/function_account_password_reset_request.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 CREATE FUNCTION maevsi.account_password_reset_request(
   email_address TEXT,
-  "language" TEXT
+  language TEXT
 ) RETURNS VOID AS $$
 DECLARE
   _notify_data RECORD;
@@ -10,7 +10,7 @@ BEGIN
   WITH updated AS (
     UPDATE maevsi_private.account
       SET password_reset_verification = gen_random_uuid()
-      WHERE account.email_address = $1
+      WHERE account.email_address = account_password_reset_request.email_address
       RETURNING *
   ) SELECT
     account.username,
@@ -28,7 +28,7 @@ BEGIN
       'account_password_reset_request',
       jsonb_pretty(jsonb_build_object(
         'account', _notify_data,
-        'template', jsonb_build_object('language', $2)
+        'template', jsonb_build_object('language', account_password_reset_request.language)
       ))
     );
   END IF;

--- a/src/deploy/function_account_registration.sql
+++ b/src/deploy/function_account_registration.sql
@@ -3,8 +3,8 @@ BEGIN;
 CREATE FUNCTION maevsi.account_registration(
   username TEXT,
   email_address TEXT,
-  "password" TEXT,
-  "language" TEXT
+  password TEXT,
+  language TEXT
 ) RETURNS UUID AS $$
 DECLARE
   _new_account_private maevsi_private.account;

--- a/src/deploy/function_achievement_unlock.sql
+++ b/src/deploy/function_achievement_unlock.sql
@@ -14,7 +14,7 @@ BEGIN
   SELECT achievement
     FROM maevsi_private.achievement_code
     INTO _achievement
-    WHERE achievement_code.id = $1 OR achievement_code.alias = $2;
+    WHERE achievement_code.id = achievement_unlock.code OR achievement_code.alias = achievement_unlock.alias;
 
   IF (_achievement IS NULL) THEN
     RAISE 'Unknown achievement!' USING ERRCODE = 'no_data_found';

--- a/src/deploy/function_event_delete.sql
+++ b/src/deploy/function_event_delete.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 CREATE FUNCTION maevsi.event_delete(
   id UUID,
-  "password" TEXT
+  password TEXT
 ) RETURNS maevsi.event AS $$
 DECLARE
   _current_account_id UUID;
@@ -10,11 +10,11 @@ DECLARE
 BEGIN
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($2, account.password_hash))) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(event_delete.password, account.password_hash))) THEN
     DELETE
       FROM maevsi.event
       WHERE
-            "event".id = $1
+            "event".id = event_delete.id
         AND "event".created_by = _current_account_id
       RETURNING * INTO _event_deleted;
 

--- a/src/deploy/function_event_guest_count_maximum.sql
+++ b/src/deploy/function_event_guest_count_maximum.sql
@@ -8,7 +8,7 @@ BEGIN
     SELECT guest_count_maximum
     FROM maevsi.event
     WHERE
-      id = $1
+      id = event_guest_count_maximum.event_id
       AND ( -- Copied from `event_select` POLICY.
         (
           visibility = 'public'

--- a/src/deploy/function_event_is_existing.sql
+++ b/src/deploy/function_event_is_existing.sql
@@ -5,7 +5,7 @@ CREATE FUNCTION maevsi.event_is_existing(
   slug TEXT
 ) RETURNS BOOLEAN AS $$
 BEGIN
-  IF (EXISTS (SELECT 1 FROM maevsi.event WHERE "event".created_by = $1 AND "event".slug = $2)) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi.event WHERE "event".created_by = event_is_existing.created_by AND "event".slug = event_is_existing.slug)) THEN
     RETURN TRUE;
   ELSE
     RETURN FALSE;

--- a/src/deploy/function_event_unlock.sql
+++ b/src/deploy/function_event_unlock.sql
@@ -16,7 +16,7 @@ BEGIN
     maevsi.invoker_account_id(), -- prevent empty string cast to UUID
     current_setting('jwt.claims.account_username', true)::TEXT,
     current_setting('jwt.claims.exp', true)::BIGINT,
-    (SELECT ARRAY(SELECT DISTINCT UNNEST(maevsi.guest_claim_array() || $1) ORDER BY 1)),
+    (SELECT ARRAY(SELECT DISTINCT UNNEST(maevsi.guest_claim_array() || event_unlock.guest_id) ORDER BY 1)),
     current_setting('jwt.claims.role', true)::TEXT
   )::maevsi.jwt;
 
@@ -26,7 +26,7 @@ BEGIN
 
   _event_id := (
     SELECT event_id FROM maevsi.guest
-    WHERE guest.id = $1
+    WHERE guest.id = event_unlock.guest_id
   );
 
   IF (_event_id IS NULL) THEN

--- a/src/deploy/function_guest_count.sql
+++ b/src/deploy/function_guest_count.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE FUNCTION maevsi.guest_count(event_id UUID)
 RETURNS INTEGER AS $$
 BEGIN
-  RETURN (SELECT COUNT(1) FROM maevsi.guest WHERE guest.event_id = $1);
+  RETURN (SELECT COUNT(1) FROM maevsi.guest WHERE guest.event_id = guest_count.event_id);
 END;
 $$ LANGUAGE PLPGSQL STRICT STABLE SECURITY DEFINER;
 

--- a/src/deploy/function_invite.sql
+++ b/src/deploy/function_invite.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 CREATE FUNCTION maevsi.invite(
   guest_id UUID,
-  "language" TEXT
+  language TEXT
 ) RETURNS VOID AS $$
 DECLARE
   _contact RECORD;
@@ -14,7 +14,7 @@ DECLARE
   _guest RECORD;
 BEGIN
   -- Guest UUID
-  SELECT * FROM maevsi.guest INTO _guest WHERE guest.id = $1;
+  SELECT * FROM maevsi.guest INTO _guest WHERE guest.id = invite.guest_id;
 
   IF (
     _guest IS NULL
@@ -71,7 +71,7 @@ BEGIN
           'eventCreatorUsername', _event_creator_username,
           'guestId', _guest.id
         ),
-        'template', jsonb_build_object('language', $2)
+        'template', jsonb_build_object('language', invite.language)
       ))
     );
 END;

--- a/src/deploy/function_jwt_refresh.sql
+++ b/src/deploy/function_jwt_refresh.sql
@@ -9,7 +9,7 @@ DECLARE
 BEGIN
   SELECT (token).id, (token).account_id, (token).account_username, (token)."exp", (token).guests, (token).role INTO _jwt
   FROM maevsi_private.jwt
-  WHERE   id = $1
+  WHERE   id = jwt_refresh.jwt_id
   AND     (token)."exp" >= _epoch_now;
 
   IF (_jwt IS NULL) THEN
@@ -17,7 +17,7 @@ BEGIN
   ELSE
     UPDATE maevsi_private.jwt
     SET token.exp = EXTRACT(EPOCH FROM ((SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP WITH TIME ZONE)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL))
-    WHERE id = $1;
+    WHERE id = jwt_refresh.jwt_id;
 
     UPDATE maevsi_private.account
     SET last_activity = DEFAULT
@@ -26,7 +26,7 @@ BEGIN
     RETURN (
       SELECT token
       FROM maevsi_private.jwt
-      WHERE   id = $1
+      WHERE   id = jwt_refresh.jwt_id
       AND     (token)."exp" >= _epoch_now
     );
   END IF;

--- a/src/deploy/function_notification_acknowledge.sql
+++ b/src/deploy/function_notification_acknowledge.sql
@@ -5,8 +5,8 @@ CREATE FUNCTION maevsi.notification_acknowledge(
   is_acknowledged BOOLEAN
 ) RETURNS VOID AS $$
 BEGIN
-  IF (EXISTS (SELECT 1 FROM maevsi_private.notification WHERE "notification".id = $1)) THEN
-    UPDATE maevsi_private.notification SET is_acknowledged = $2 WHERE "notification".id = $1;
+  IF (EXISTS (SELECT 1 FROM maevsi_private.notification WHERE "notification".id = notification_acknowledge.id)) THEN
+    UPDATE maevsi_private.notification SET is_acknowledged = notification_acknowledge.is_acknowledged WHERE "notification".id = notification_acknowledge.id;
   ELSE
     RAISE 'Notification with given id not found!' USING ERRCODE = 'no_data_found';
   END IF;

--- a/src/deploy/function_profile_picture_set.sql
+++ b/src/deploy/function_profile_picture_set.sql
@@ -7,11 +7,11 @@ BEGIN
   INSERT INTO maevsi.profile_picture(account_id, upload_id)
   VALUES (
     current_setting('jwt.claims.account_id')::UUID,
-    $1
+    profile_picture_set.upload_id
   )
   ON CONFLICT (account_id)
   DO UPDATE
-  SET upload_id = $1;
+  SET upload_id = profile_picture_set.upload_id;
 END;
 $$ LANGUAGE PLPGSQL STRICT VOLATILE SECURITY INVOKER;
 

--- a/src/deploy/function_upload_create.sql
+++ b/src/deploy/function_upload_create.sql
@@ -10,13 +10,13 @@ BEGIN
     SELECT SUM(upload.size_byte)
     FROM maevsi.upload
     WHERE upload.account_id = current_setting('jwt.claims.account_id')::UUID
-  ), 0) + $1 <= (
+  ), 0) + upload_create.size_byte <= (
     SELECT upload_quota_bytes
     FROM maevsi_private.account
     WHERE account.id = current_setting('jwt.claims.account_id')::UUID
   )) THEN
     INSERT INTO maevsi.upload(account_id, size_byte)
-    VALUES (current_setting('jwt.claims.account_id')::UUID, $1)
+    VALUES (current_setting('jwt.claims.account_id')::UUID, upload_create.size_byte)
     RETURNING upload.id INTO _upload;
 
     RETURN _upload;

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -281,13 +281,13 @@ COMMENT ON TYPE maevsi.social_network IS 'Social networks.';
 
 CREATE FUNCTION maevsi.account_delete(password text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _current_account_id UUID;
 BEGIN
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($1, account.password_hash))) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(account_delete.password, account.password_hash))) THEN
     IF (EXISTS (SELECT 1 FROM maevsi.event WHERE event.created_by = _current_account_id)) THEN
       RAISE 'You still own events!' USING ERRCODE = 'foreign_key_violation';
     ELSE
@@ -297,7 +297,7 @@ BEGIN
     RAISE 'Account with given password not found!' USING ERRCODE = 'invalid_password';
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_delete(password text) OWNER TO postgres;
@@ -315,14 +315,14 @@ COMMENT ON FUNCTION maevsi.account_delete(password text) IS 'Allows to delete an
 
 CREATE FUNCTION maevsi.account_email_address_verification(code uuid) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _account maevsi_private.account;
 BEGIN
   SELECT *
     FROM maevsi_private.account
     INTO _account
-    WHERE account.email_address_verification = $1;
+    WHERE account.email_address_verification = account_email_address_verification.code;
 
   IF (_account IS NULL) THEN
     RAISE 'Unknown verification code!' USING ERRCODE = 'no_data_found';
@@ -334,9 +334,9 @@ BEGIN
 
   UPDATE maevsi_private.account
     SET email_address_verification = NULL
-    WHERE email_address_verification = $1;
+    WHERE email_address_verification = account_email_address_verification.code;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_email_address_verification(code uuid) OWNER TO postgres;
@@ -354,23 +354,23 @@ COMMENT ON FUNCTION maevsi.account_email_address_verification(code uuid) IS 'Set
 
 CREATE FUNCTION maevsi.account_password_change(password_current text, password_new text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _current_account_id UUID;
 BEGIN
-  IF (char_length($2) < 8) THEN
+  IF (char_length(account_password_change.password_new) < 8) THEN
       RAISE 'New password too short!' USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($1, account.password_hash))) THEN
-    UPDATE maevsi_private.account SET password_hash = crypt($2, gen_salt('bf')) WHERE account.id = _current_account_id;
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(account_password_change.password_current, account.password_hash))) THEN
+    UPDATE maevsi_private.account SET password_hash = crypt(account_password_change.password_new, gen_salt('bf')) WHERE account.id = _current_account_id;
   ELSE
     RAISE 'Account with given password not found!' USING ERRCODE = 'invalid_password';
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_password_change(password_current text, password_new text) OWNER TO postgres;
@@ -388,18 +388,18 @@ COMMENT ON FUNCTION maevsi.account_password_change(password_current text, passwo
 
 CREATE FUNCTION maevsi.account_password_reset(code uuid, password text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _account maevsi_private.account;
 BEGIN
-  IF (char_length($2) < 8) THEN
+  IF (char_length(account_password_reset.password) < 8) THEN
     RAISE 'Password too short!' USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
   SELECT *
     FROM maevsi_private.account
     INTO _account
-    WHERE account.password_reset_verification = $1;
+    WHERE account.password_reset_verification = account_password_reset.code;
 
   IF (_account IS NULL) THEN
     RAISE 'Unknown reset code!' USING ERRCODE = 'no_data_found';
@@ -411,11 +411,11 @@ BEGIN
 
   UPDATE maevsi_private.account
     SET
-      password_hash = crypt($2, gen_salt('bf')),
+      password_hash = crypt(account_password_reset.password, gen_salt('bf')),
       password_reset_verification = NULL
-    WHERE account.password_reset_verification = $1;
+    WHERE account.password_reset_verification = account_password_reset.code;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_password_reset(code uuid, password text) OWNER TO postgres;
@@ -433,14 +433,14 @@ COMMENT ON FUNCTION maevsi.account_password_reset(code uuid, password text) IS '
 
 CREATE FUNCTION maevsi.account_password_reset_request(email_address text, language text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _notify_data RECORD;
 BEGIN
   WITH updated AS (
     UPDATE maevsi_private.account
       SET password_reset_verification = gen_random_uuid()
-      WHERE account.email_address = $1
+      WHERE account.email_address = account_password_reset_request.email_address
       RETURNING *
   ) SELECT
     account.username,
@@ -458,12 +458,12 @@ BEGIN
       'account_password_reset_request',
       jsonb_pretty(jsonb_build_object(
         'account', _notify_data,
-        'template', jsonb_build_object('language', $2)
+        'template', jsonb_build_object('language', account_password_reset_request.language)
       ))
     );
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_password_reset_request(email_address text, language text) OWNER TO postgres;
@@ -544,20 +544,20 @@ COMMENT ON FUNCTION maevsi.account_registration(username text, email_address tex
 
 CREATE FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _new_account_notify RECORD;
 BEGIN
   RAISE 'Refreshing registrations is currently not available due to missing rate limiting!' USING ERRCODE = 'deprecated_feature';
 
-  IF (NOT EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = $1)) THEN
+  IF (NOT EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = account_registration_refresh.account_id)) THEN
     RAISE 'An account with this account id does not exists!' USING ERRCODE = 'invalid_parameter_value';
   END IF;
 
   WITH updated AS (
     UPDATE maevsi_private.account
       SET email_address_verification = DEFAULT
-      WHERE account.id = $1
+      WHERE account.id = account_registration_refresh.account_id
       RETURNING *
   ) SELECT
     account.username,
@@ -572,11 +572,11 @@ BEGIN
     'account_registration',
     jsonb_pretty(jsonb_build_object(
       'account', row_to_json(_new_account_notify),
-      'template', jsonb_build_object('language', $2)
+      'template', jsonb_build_object('language', account_registration_refresh.language)
     ))
   );
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) OWNER TO postgres;
@@ -616,7 +616,7 @@ COMMENT ON FUNCTION maevsi.account_upload_quota_bytes() IS 'Gets the total uploa
 
 CREATE FUNCTION maevsi.achievement_unlock(code uuid, alias text) RETURNS uuid
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _account_id UUID;
   _achievement maevsi.achievement_type;
@@ -627,7 +627,7 @@ BEGIN
   SELECT achievement
     FROM maevsi_private.achievement_code
     INTO _achievement
-    WHERE achievement_code.id = $1 OR achievement_code.alias = $2;
+    WHERE achievement_code.id = achievement_unlock.code OR achievement_code.alias = achievement_unlock.alias;
 
   IF (_achievement IS NULL) THEN
     RAISE 'Unknown achievement!' USING ERRCODE = 'no_data_found';
@@ -650,7 +650,7 @@ BEGIN
 
   RETURN _achievement_id;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.achievement_unlock(code uuid, alias text) OWNER TO postgres;
@@ -916,18 +916,18 @@ A vector used for full-text search on events.';
 
 CREATE FUNCTION maevsi.event_delete(id uuid, password text) RETURNS maevsi.event
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _current_account_id UUID;
   _event_deleted maevsi.event;
 BEGIN
   _current_account_id := current_setting('jwt.claims.account_id')::UUID;
 
-  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt($2, account.password_hash))) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi_private.account WHERE account.id = _current_account_id AND account.password_hash = crypt(event_delete.password, account.password_hash))) THEN
     DELETE
       FROM maevsi.event
       WHERE
-            "event".id = $1
+            "event".id = event_delete.id
         AND "event".created_by = _current_account_id
       RETURNING * INTO _event_deleted;
 
@@ -940,7 +940,7 @@ BEGIN
     RAISE 'Account with given password not found!' USING ERRCODE = 'invalid_password';
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.event_delete(id uuid, password text) OWNER TO postgres;
@@ -958,13 +958,13 @@ COMMENT ON FUNCTION maevsi.event_delete(id uuid, password text) IS 'Allows to de
 
 CREATE FUNCTION maevsi.event_guest_count_maximum(event_id uuid) RETURNS integer
     LANGUAGE plpgsql STABLE STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 BEGIN
   RETURN (
     SELECT guest_count_maximum
     FROM maevsi.event
     WHERE
-      id = $1
+      id = event_guest_count_maximum.event_id
       AND ( -- Copied from `event_select` POLICY.
         (
           visibility = 'public'
@@ -984,7 +984,7 @@ BEGIN
       )
   );
 END
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.event_guest_count_maximum(event_id uuid) OWNER TO postgres;
@@ -1002,15 +1002,15 @@ COMMENT ON FUNCTION maevsi.event_guest_count_maximum(event_id uuid) IS 'Add a fu
 
 CREATE FUNCTION maevsi.event_is_existing(created_by uuid, slug text) RETURNS boolean
     LANGUAGE plpgsql STABLE STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 BEGIN
-  IF (EXISTS (SELECT 1 FROM maevsi.event WHERE "event".created_by = $1 AND "event".slug = $2)) THEN
+  IF (EXISTS (SELECT 1 FROM maevsi.event WHERE "event".created_by = event_is_existing.created_by AND "event".slug = event_is_existing.slug)) THEN
     RETURN TRUE;
   ELSE
     RETURN FALSE;
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.event_is_existing(created_by uuid, slug text) OWNER TO postgres;
@@ -1062,7 +1062,7 @@ COMMENT ON FUNCTION maevsi.event_search(query text, language maevsi.language) IS
 
 CREATE FUNCTION maevsi.event_unlock(guest_id uuid) RETURNS maevsi.event_unlock_response
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _jwt_id UUID;
   _jwt maevsi.jwt;
@@ -1076,7 +1076,7 @@ BEGIN
     maevsi.invoker_account_id(), -- prevent empty string cast to UUID
     current_setting('jwt.claims.account_username', true)::TEXT,
     current_setting('jwt.claims.exp', true)::BIGINT,
-    (SELECT ARRAY(SELECT DISTINCT UNNEST(maevsi.guest_claim_array() || $1) ORDER BY 1)),
+    (SELECT ARRAY(SELECT DISTINCT UNNEST(maevsi.guest_claim_array() || event_unlock.guest_id) ORDER BY 1)),
     current_setting('jwt.claims.role', true)::TEXT
   )::maevsi.jwt;
 
@@ -1086,7 +1086,7 @@ BEGIN
 
   _event_id := (
     SELECT event_id FROM maevsi.guest
-    WHERE guest.id = $1
+    WHERE guest.id = event_unlock.guest_id
   );
 
   IF (_event_id IS NULL) THEN
@@ -1113,7 +1113,7 @@ BEGIN
   END IF;
 
   RETURN (_event_creator_account_username, _event.slug, _jwt)::maevsi.event_unlock_response;
-END $_$;
+END $$;
 
 
 ALTER FUNCTION maevsi.event_unlock(guest_id uuid) OWNER TO postgres;
@@ -1259,11 +1259,11 @@ COMMENT ON FUNCTION maevsi.guest_contact_ids() IS 'Returns contact ids that are 
 
 CREATE FUNCTION maevsi.guest_count(event_id uuid) RETURNS integer
     LANGUAGE plpgsql STABLE STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 BEGIN
-  RETURN (SELECT COUNT(1) FROM maevsi.guest WHERE guest.event_id = $1);
+  RETURN (SELECT COUNT(1) FROM maevsi.guest WHERE guest.event_id = guest_count.event_id);
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.guest_count(event_id uuid) OWNER TO postgres;
@@ -1281,7 +1281,7 @@ COMMENT ON FUNCTION maevsi.guest_count(event_id uuid) IS 'Returns the guest coun
 
 CREATE FUNCTION maevsi.invite(guest_id uuid, language text) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _contact RECORD;
   _email_address TEXT;
@@ -1292,7 +1292,7 @@ DECLARE
   _guest RECORD;
 BEGIN
   -- Guest UUID
-  SELECT * FROM maevsi.guest INTO _guest WHERE guest.id = $1;
+  SELECT * FROM maevsi.guest INTO _guest WHERE guest.id = invite.guest_id;
 
   IF (
     _guest IS NULL
@@ -1349,11 +1349,11 @@ BEGIN
           'eventCreatorUsername', _event_creator_username,
           'guestId', _guest.id
         ),
-        'template', jsonb_build_object('language', $2)
+        'template', jsonb_build_object('language', invite.language)
       ))
     );
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.invite(guest_id uuid, language text) OWNER TO postgres;
@@ -1393,14 +1393,14 @@ COMMENT ON FUNCTION maevsi.invoker_account_id() IS 'Returns the session''s accou
 
 CREATE FUNCTION maevsi.jwt_refresh(jwt_id uuid) RETURNS maevsi.jwt
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
   _epoch_now BIGINT := EXTRACT(EPOCH FROM (SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP WITH TIME ZONE)));
   _jwt maevsi.jwt;
 BEGIN
   SELECT (token).id, (token).account_id, (token).account_username, (token)."exp", (token).guests, (token).role INTO _jwt
   FROM maevsi_private.jwt
-  WHERE   id = $1
+  WHERE   id = jwt_refresh.jwt_id
   AND     (token)."exp" >= _epoch_now;
 
   IF (_jwt IS NULL) THEN
@@ -1408,7 +1408,7 @@ BEGIN
   ELSE
     UPDATE maevsi_private.jwt
     SET token.exp = EXTRACT(EPOCH FROM ((SELECT date_trunc('second', CURRENT_TIMESTAMP::TIMESTAMP WITH TIME ZONE)) + COALESCE(current_setting('maevsi.jwt_expiry_duration', true), '1 day')::INTERVAL))
-    WHERE id = $1;
+    WHERE id = jwt_refresh.jwt_id;
 
     UPDATE maevsi_private.account
     SET last_activity = DEFAULT
@@ -1417,12 +1417,12 @@ BEGIN
     RETURN (
       SELECT token
       FROM maevsi_private.jwt
-      WHERE   id = $1
+      WHERE   id = jwt_refresh.jwt_id
       AND     (token)."exp" >= _epoch_now
     );
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.jwt_refresh(jwt_id uuid) OWNER TO postgres;
@@ -1508,15 +1508,15 @@ ALTER FUNCTION maevsi.legal_term_change() OWNER TO postgres;
 
 CREATE FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) RETURNS void
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 BEGIN
-  IF (EXISTS (SELECT 1 FROM maevsi_private.notification WHERE "notification".id = $1)) THEN
-    UPDATE maevsi_private.notification SET is_acknowledged = $2 WHERE "notification".id = $1;
+  IF (EXISTS (SELECT 1 FROM maevsi_private.notification WHERE "notification".id = notification_acknowledge.id)) THEN
+    UPDATE maevsi_private.notification SET is_acknowledged = notification_acknowledge.is_acknowledged WHERE "notification".id = notification_acknowledge.id;
   ELSE
     RAISE 'Notification with given id not found!' USING ERRCODE = 'no_data_found';
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) OWNER TO postgres;
@@ -1534,18 +1534,18 @@ COMMENT ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boo
 
 CREATE FUNCTION maevsi.profile_picture_set(upload_id uuid) RETURNS void
     LANGUAGE plpgsql STRICT
-    AS $_$
+    AS $$
 BEGIN
   INSERT INTO maevsi.profile_picture(account_id, upload_id)
   VALUES (
     current_setting('jwt.claims.account_id')::UUID,
-    $1
+    profile_picture_set.upload_id
   )
   ON CONFLICT (account_id)
   DO UPDATE
-  SET upload_id = $1;
+  SET upload_id = profile_picture_set.upload_id;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.profile_picture_set(upload_id uuid) OWNER TO postgres;
@@ -1791,7 +1791,7 @@ Timestamp of when the upload was created, defaults to the current timestamp.';
 
 CREATE FUNCTION maevsi.upload_create(size_byte bigint) RETURNS maevsi.upload
     LANGUAGE plpgsql STRICT SECURITY DEFINER
-    AS $_$
+    AS $$
 DECLARE
     _upload maevsi.upload;
 BEGIN
@@ -1799,13 +1799,13 @@ BEGIN
     SELECT SUM(upload.size_byte)
     FROM maevsi.upload
     WHERE upload.account_id = current_setting('jwt.claims.account_id')::UUID
-  ), 0) + $1 <= (
+  ), 0) + upload_create.size_byte <= (
     SELECT upload_quota_bytes
     FROM maevsi_private.account
     WHERE account.id = current_setting('jwt.claims.account_id')::UUID
   )) THEN
     INSERT INTO maevsi.upload(account_id, size_byte)
-    VALUES (current_setting('jwt.claims.account_id')::UUID, $1)
+    VALUES (current_setting('jwt.claims.account_id')::UUID, upload_create.size_byte)
     RETURNING upload.id INTO _upload;
 
     RETURN _upload;
@@ -1813,7 +1813,7 @@ BEGIN
     RAISE 'Upload quota limit reached!' USING ERRCODE = 'disk_full';
   END IF;
 END;
-$_$;
+$$;
 
 
 ALTER FUNCTION maevsi.upload_create(size_byte bigint) OWNER TO postgres;


### PR DESCRIPTION
Instead of `$1` and `$2`, we use `function.parameter` syntax everywhere now.