### PR TITLE
test(account-block): prevent possibility for function replacement

### DIFF
--- a/src/deploy/test_account_block.sql
+++ b/src/deploy/test_account_block.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE OR REPLACE FUNCTION maevsi_test.account_create (
+CREATE FUNCTION maevsi_test.account_create (
   _username TEXT,
   _email TEXT
 ) RETURNS UUID AS $$
@@ -19,7 +19,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.account_remove (
+CREATE FUNCTION maevsi_test.account_remove (
   _username TEXT
 ) RETURNS VOID AS $$
 DECLARE
@@ -40,7 +40,7 @@ BEGIN
   END IF;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.contact_select_by_account_id (
+CREATE FUNCTION maevsi_test.contact_select_by_account_id (
   _account_id UUID
 ) RETURNS UUID AS $$
 DECLARE
@@ -53,7 +53,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.contact_create (
+CREATE FUNCTION maevsi_test.contact_create (
   _created_by UUID,
   _email_address TEXT
 ) RETURNS UUID AS $$
@@ -79,7 +79,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.event_create (
+CREATE FUNCTION maevsi_test.event_create (
   _created_by UUID,
   _name TEXT,
   _slug TEXT,
@@ -101,7 +101,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.guest_create (
+CREATE FUNCTION maevsi_test.guest_create (
   _created_by UUID,
   _event_id UUID,
   _contact_id UUID
@@ -121,14 +121,14 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.event_category_create (
+CREATE FUNCTION maevsi_test.event_category_create (
   _category TEXT
 ) RETURNS VOID AS $$
 BEGIN
   INSERT INTO maevsi.event_category(category) VALUES (_category);
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.event_category_mapping_create (
+CREATE FUNCTION maevsi_test.event_category_mapping_create (
   _created_by UUID,
   _event_id UUID,
   _category TEXT
@@ -143,7 +143,7 @@ BEGIN
   SET LOCAL role = 'postgres';
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.account_block_create (
+CREATE FUNCTION maevsi_test.account_block_create (
   _created_by UUID,
   _blocked_account_id UUID
 ) RETURNS UUID AS $$
@@ -162,7 +162,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.account_block_remove (
+CREATE FUNCTION maevsi_test.account_block_remove (
   _created_by UUID,
   _blocked_account_id UUID
 ) RETURNS VOID AS $$
@@ -173,7 +173,7 @@ BEGIN
   WHERE created_by = _created_by  and blocked_account_id = _blocked_account_id;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.event_test (
+CREATE FUNCTION maevsi_test.event_test (
   _test_case TEXT,
   _account_id UUID,
   _expected_result UUID[]
@@ -198,7 +198,7 @@ BEGIN
   SET LOCAL role = 'postgres';
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.event_category_mapping_test (
+CREATE FUNCTION maevsi_test.event_category_mapping_test (
   _test_case TEXT,
   _account_id UUID,
   _expected_result UUID[]
@@ -223,7 +223,7 @@ BEGIN
   SET LOCAL role = 'postgres';
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.contact_test (
+CREATE FUNCTION maevsi_test.contact_test (
   _test_case TEXT,
   _account_id UUID,
   _expected_result UUID[]
@@ -250,7 +250,7 @@ BEGIN
   SET LOCAL role = 'postgres';
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.guest_test (
+CREATE FUNCTION maevsi_test.guest_test (
   _test_case TEXT,
   _account_id UUID,
   _expected_result UUID[]
@@ -312,7 +312,7 @@ BEGIN
   RETURN _result;
 END $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION maevsi_test.uuid_array_test (
+CREATE FUNCTION maevsi_test.uuid_array_test (
   _test_case TEXT,
   _array UUID[],
   _expected_array UUID[]


### PR DESCRIPTION
Developers should notice if a function is created more than once. Such duplication is likely unintended.
It can result in extensive time for debugging to find the source for ambiguity.

I know using the replace may help while creating tests, but I'd say it must not necessarily be committed.