### PR TITLE
test(ci): customize superuser name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ FROM quay.io/debezium/postgres:17 AS test-build
 
 ENV POSTGRES_DB=maevsi
 ENV POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+ENV POSTGRES_USER=ci
 
 WORKDIR /srv/app
 
@@ -47,10 +48,10 @@ COPY ./src ./
 
 RUN export SQITCH_TARGET="$(cat SQITCH_TARGET.env)" \
   && docker-entrypoint.sh postgres & \
-  while ! pg_isready -h localhost -U postgres -p 5432; do sleep 1; done \
-  && sqitch deploy -t db:pg://postgres:postgres@/maevsi \
-  && pg_dump -s -h localhost -U postgres -p 5432 maevsi | sed -e '/^-- Dumped/d' > schema.sql \
-  && sqitch revert -t db:pg://postgres:postgres@/maevsi
+  while ! pg_isready -h localhost -U ci -p 5432; do sleep 1; done \
+  && sqitch deploy -t db:pg://ci:postgres@/maevsi \
+  && pg_dump -s -h localhost -U ci -p 5432 maevsi | sed -e '/^-- Dumped/d' > schema.sql \
+  && sqitch revert -t db:pg://ci:postgres@/maevsi
 
 
 ##############################

--- a/src/deploy/schema_test.sql
+++ b/src/deploy/schema_test.sql
@@ -4,4 +4,6 @@ CREATE SCHEMA maevsi_test;
 
 COMMENT ON SCHEMA maevsi_test IS 'Schema for test functions.';
 
+GRANT USAGE ON SCHEMA maevsi_test TO maevsi_anonymous, maevsi_account;
+
 COMMIT;

--- a/src/deploy/test_account_blocking.sql
+++ b/src/deploy/test_account_blocking.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-CREATE FUNCTION maevsi_test.set_local_superuser()
-RETURNS void AS $$
+CREATE PROCEDURE maevsi_test.set_local_superuser()
+AS $$
 DECLARE
   _superuser_name TEXT;
 BEGIN
@@ -18,7 +18,7 @@ BEGIN
   END IF;
 END $$ LANGUAGE plpgsql;
 
-GRANT EXECUTE ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_anonymous, maevsi_account;
+GRANT EXECUTE ON PROCEDURE maevsi_test.set_local_superuser() TO maevsi_anonymous, maevsi_account;
 
 
 CREATE OR REPLACE FUNCTION maevsi_test.account_create (
@@ -57,7 +57,7 @@ BEGIN
 
     PERFORM maevsi.account_delete('password');
 
-    PERFORM maevsi_test.set_local_superuser();
+    CALL maevsi_test.set_local_superuser();
   END IF;
 END $$ LANGUAGE plpgsql;
 
@@ -95,7 +95,7 @@ BEGIN
     UPDATE maevsi.contact SET account_id = _account_id WHERE id = _id;
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -117,7 +117,7 @@ BEGIN
   VALUES (_author_account_id, _name, _slug, _start::TIMESTAMP WITH TIME ZONE, _visibility::maevsi.event_visibility)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -137,7 +137,7 @@ BEGIN
   VALUES (_contact_id, _event_id)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -161,7 +161,7 @@ BEGIN
   INSERT INTO maevsi.event_category_mapping(event_id, category)
   VALUES (_event_id, _category);
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.account_block_create (
@@ -178,7 +178,7 @@ BEGIN
   VALUES (_author_account_id, _blocked_Account_id)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -216,7 +216,7 @@ BEGIN
     RAISE EXCEPTION 'some event is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.event_category_mapping_test (
@@ -241,7 +241,7 @@ BEGIN
     RAISE EXCEPTION 'some event_category_mappings is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.contact_test (
@@ -268,7 +268,7 @@ BEGIN
     RAISE EXCEPTION 'some contact is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.invitation_test (
@@ -293,7 +293,7 @@ BEGIN
     RAISE EXCEPTION 'some invitation is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE FUNCTION maevsi_test.invitation_claim_from_account_invitation (
@@ -328,7 +328,7 @@ BEGIN
 
   EXECUTE 'SET LOCAL jwt.claims.invitations = ''[' || _text || ']''';
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _result;
 END $$ LANGUAGE plpgsql;

--- a/src/deploy/test_account_blocking.sql
+++ b/src/deploy/test_account_blocking.sql
@@ -1,5 +1,26 @@
 BEGIN;
 
+CREATE FUNCTION maevsi_test.set_local_superuser()
+RETURNS void AS $$
+DECLARE
+  _superuser_name TEXT;
+BEGIN
+  SELECT usename INTO _superuser_name
+  FROM pg_user
+  WHERE usesuper = true
+  ORDER BY usename
+  LIMIT 1;
+
+  IF _superuser_name IS NOT NULL THEN
+    EXECUTE format('SET LOCAL role = %I', _superuser_name);
+  ELSE
+    RAISE NOTICE 'No superuser found!';
+  END IF;
+END $$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_anonymous, maevsi_account;
+
+
 CREATE OR REPLACE FUNCTION maevsi_test.account_create (
   _username TEXT,
   _email TEXT
@@ -36,7 +57,7 @@ BEGIN
 
     PERFORM maevsi.account_delete('password');
 
-    SET LOCAL role = 'postgres';
+    PERFORM maevsi_test.set_local_superuser();
   END IF;
 END $$ LANGUAGE plpgsql;
 
@@ -74,7 +95,7 @@ BEGIN
     UPDATE maevsi.contact SET account_id = _account_id WHERE id = _id;
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -96,7 +117,7 @@ BEGIN
   VALUES (_author_account_id, _name, _slug, _start::TIMESTAMP WITH TIME ZONE, _visibility::maevsi.event_visibility)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -116,7 +137,7 @@ BEGIN
   VALUES (_contact_id, _event_id)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -140,7 +161,7 @@ BEGIN
   INSERT INTO maevsi.event_category_mapping(event_id, category)
   VALUES (_event_id, _category);
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.account_block_create (
@@ -157,7 +178,7 @@ BEGIN
   VALUES (_author_account_id, _blocked_Account_id)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$ LANGUAGE plpgsql;
@@ -195,7 +216,7 @@ BEGIN
     RAISE EXCEPTION 'some event is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.event_category_mapping_test (
@@ -220,7 +241,7 @@ BEGIN
     RAISE EXCEPTION 'some event_category_mappings is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.contact_test (
@@ -247,7 +268,7 @@ BEGIN
     RAISE EXCEPTION 'some contact is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION maevsi_test.invitation_test (
@@ -272,7 +293,7 @@ BEGIN
     RAISE EXCEPTION 'some invitation is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$ LANGUAGE plpgsql;
 
 CREATE FUNCTION maevsi_test.invitation_claim_from_account_invitation (
@@ -307,7 +328,7 @@ BEGIN
 
   EXECUTE 'SET LOCAL jwt.claims.invitations = ''[' || _text || ']''';
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _result;
 END $$ LANGUAGE plpgsql;

--- a/src/revert/test_account_blocking.sql
+++ b/src/revert/test_account_blocking.sql
@@ -16,5 +16,6 @@ DROP FUNCTION maevsi_test.invitation_create(UUID, UUID, UUID);
 DROP FUNCTION maevsi_test.invitation_test(TEXT, UUID, UUID[]);
 DROP FUNCTION maevsi_test.invitation_claim_from_account_invitation(UUID);
 DROP FUNCTION maevsi_test.uuid_array_test(TEXT, UUID[], UUID[]);
+DROP FUNCTION maevsi_test.set_local_superuser();
 
 COMMIT;

--- a/src/revert/test_account_blocking.sql
+++ b/src/revert/test_account_blocking.sql
@@ -16,6 +16,6 @@ DROP FUNCTION maevsi_test.invitation_create(UUID, UUID, UUID);
 DROP FUNCTION maevsi_test.invitation_test(TEXT, UUID, UUID[]);
 DROP FUNCTION maevsi_test.invitation_claim_from_account_invitation(UUID);
 DROP FUNCTION maevsi_test.uuid_array_test(TEXT, UUID[], UUID[]);
-DROP FUNCTION maevsi_test.set_local_superuser();
+DROP PROCEDURE maevsi_test.set_local_superuser();
 
 COMMIT;

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -16,64 +16,64 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: maevsi; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: maevsi; Type: SCHEMA; Schema: -; Owner: ci
 --
 
 CREATE SCHEMA maevsi;
 
 
-ALTER SCHEMA maevsi OWNER TO postgres;
+ALTER SCHEMA maevsi OWNER TO ci;
 
 --
--- Name: SCHEMA maevsi; Type: COMMENT; Schema: -; Owner: postgres
+-- Name: SCHEMA maevsi; Type: COMMENT; Schema: -; Owner: ci
 --
 
 COMMENT ON SCHEMA maevsi IS 'Is used by PostGraphile.';
 
 
 --
--- Name: maevsi_private; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: maevsi_private; Type: SCHEMA; Schema: -; Owner: ci
 --
 
 CREATE SCHEMA maevsi_private;
 
 
-ALTER SCHEMA maevsi_private OWNER TO postgres;
+ALTER SCHEMA maevsi_private OWNER TO ci;
 
 --
--- Name: SCHEMA maevsi_private; Type: COMMENT; Schema: -; Owner: postgres
+-- Name: SCHEMA maevsi_private; Type: COMMENT; Schema: -; Owner: ci
 --
 
 COMMENT ON SCHEMA maevsi_private IS 'Contains account information and is not used by PostGraphile.';
 
 
 --
--- Name: maevsi_test; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: maevsi_test; Type: SCHEMA; Schema: -; Owner: ci
 --
 
 CREATE SCHEMA maevsi_test;
 
 
-ALTER SCHEMA maevsi_test OWNER TO postgres;
+ALTER SCHEMA maevsi_test OWNER TO ci;
 
 --
--- Name: SCHEMA maevsi_test; Type: COMMENT; Schema: -; Owner: postgres
+-- Name: SCHEMA maevsi_test; Type: COMMENT; Schema: -; Owner: ci
 --
 
 COMMENT ON SCHEMA maevsi_test IS 'Schema for test functions.';
 
 
 --
--- Name: sqitch; Type: SCHEMA; Schema: -; Owner: postgres
+-- Name: sqitch; Type: SCHEMA; Schema: -; Owner: ci
 --
 
 CREATE SCHEMA sqitch;
 
 
-ALTER SCHEMA sqitch OWNER TO postgres;
+ALTER SCHEMA sqitch OWNER TO ci;
 
 --
--- Name: SCHEMA sqitch; Type: COMMENT; Schema: -; Owner: postgres
+-- Name: SCHEMA sqitch; Type: COMMENT; Schema: -; Owner: ci
 --
 
 COMMENT ON SCHEMA sqitch IS 'Sqitch database deployment metadata v1.1.';
@@ -94,7 +94,7 @@ COMMENT ON EXTENSION pgcrypto IS 'Provides password hashing functions.';
 
 
 --
--- Name: achievement_type; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: achievement_type; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.achievement_type AS ENUM (
@@ -103,17 +103,17 @@ CREATE TYPE maevsi.achievement_type AS ENUM (
 );
 
 
-ALTER TYPE maevsi.achievement_type OWNER TO postgres;
+ALTER TYPE maevsi.achievement_type OWNER TO ci;
 
 --
--- Name: TYPE achievement_type; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE achievement_type; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.achievement_type IS 'Achievements that can be unlocked by users.';
 
 
 --
--- Name: event_size; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: event_size; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.event_size AS ENUM (
@@ -124,17 +124,17 @@ CREATE TYPE maevsi.event_size AS ENUM (
 );
 
 
-ALTER TYPE maevsi.event_size OWNER TO postgres;
+ALTER TYPE maevsi.event_size OWNER TO ci;
 
 --
--- Name: TYPE event_size; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE event_size; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.event_size IS 'Possible event sizes: small, medium, large, huge.';
 
 
 --
--- Name: jwt; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: jwt; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.jwt AS (
@@ -147,10 +147,10 @@ CREATE TYPE maevsi.jwt AS (
 );
 
 
-ALTER TYPE maevsi.jwt OWNER TO postgres;
+ALTER TYPE maevsi.jwt OWNER TO ci;
 
 --
--- Name: event_unlock_response; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: event_unlock_response; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.event_unlock_response AS (
@@ -160,10 +160,10 @@ CREATE TYPE maevsi.event_unlock_response AS (
 );
 
 
-ALTER TYPE maevsi.event_unlock_response OWNER TO postgres;
+ALTER TYPE maevsi.event_unlock_response OWNER TO ci;
 
 --
--- Name: event_visibility; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: event_visibility; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.event_visibility AS ENUM (
@@ -172,17 +172,17 @@ CREATE TYPE maevsi.event_visibility AS ENUM (
 );
 
 
-ALTER TYPE maevsi.event_visibility OWNER TO postgres;
+ALTER TYPE maevsi.event_visibility OWNER TO ci;
 
 --
--- Name: TYPE event_visibility; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE event_visibility; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.event_visibility IS 'Possible visibilities of events and event groups: public, private.';
 
 
 --
--- Name: invitation_feedback; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: invitation_feedback; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.invitation_feedback AS ENUM (
@@ -191,17 +191,17 @@ CREATE TYPE maevsi.invitation_feedback AS ENUM (
 );
 
 
-ALTER TYPE maevsi.invitation_feedback OWNER TO postgres;
+ALTER TYPE maevsi.invitation_feedback OWNER TO ci;
 
 --
--- Name: TYPE invitation_feedback; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE invitation_feedback; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.invitation_feedback IS 'Possible answers to an invitation: accepted, canceled.';
 
 
 --
--- Name: invitation_feedback_paper; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: invitation_feedback_paper; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.invitation_feedback_paper AS ENUM (
@@ -211,17 +211,17 @@ CREATE TYPE maevsi.invitation_feedback_paper AS ENUM (
 );
 
 
-ALTER TYPE maevsi.invitation_feedback_paper OWNER TO postgres;
+ALTER TYPE maevsi.invitation_feedback_paper OWNER TO ci;
 
 --
--- Name: TYPE invitation_feedback_paper; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE invitation_feedback_paper; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.invitation_feedback_paper IS 'Possible choices on how to receive a paper invitation: none, paper, digital.';
 
 
 --
--- Name: language; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: language; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.language AS ENUM (
@@ -230,17 +230,17 @@ CREATE TYPE maevsi.language AS ENUM (
 );
 
 
-ALTER TYPE maevsi.language OWNER TO postgres;
+ALTER TYPE maevsi.language OWNER TO ci;
 
 --
--- Name: TYPE language; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE language; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.language IS 'Supported ISO 639 language codes.';
 
 
 --
--- Name: social_network; Type: TYPE; Schema: maevsi; Owner: postgres
+-- Name: social_network; Type: TYPE; Schema: maevsi; Owner: ci
 --
 
 CREATE TYPE maevsi.social_network AS ENUM (
@@ -251,17 +251,17 @@ CREATE TYPE maevsi.social_network AS ENUM (
 );
 
 
-ALTER TYPE maevsi.social_network OWNER TO postgres;
+ALTER TYPE maevsi.social_network OWNER TO ci;
 
 --
--- Name: TYPE social_network; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TYPE social_network; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TYPE maevsi.social_network IS 'Social networks.';
 
 
 --
--- Name: account_delete(text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_delete(text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_delete(password text) RETURNS void
@@ -285,17 +285,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_delete(password text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_delete(password text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_delete(password text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_delete(password text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_delete(password text) IS 'Allows to delete an account.';
 
 
 --
--- Name: account_email_address_verification(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_email_address_verification(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_email_address_verification(code uuid) RETURNS void
@@ -324,17 +324,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_email_address_verification(code uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_email_address_verification(code uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION account_email_address_verification(code uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_email_address_verification(code uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_email_address_verification(code uuid) IS 'Sets the account''s email address verification code to `NULL` for which the email address verification code equals the one passed and is up to date.';
 
 
 --
--- Name: account_password_change(text, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_password_change(text, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_password_change(password_current text, password_new text) RETURNS void
@@ -358,17 +358,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_password_change(password_current text, password_new text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_password_change(password_current text, password_new text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_password_change(password_current text, password_new text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_change(password_current text, password_new text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_password_change(password_current text, password_new text) IS 'Allows to change an account''s password.';
 
 
 --
--- Name: account_password_reset(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_password_reset(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_password_reset(code uuid, password text) RETURNS void
@@ -403,17 +403,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_password_reset(code uuid, password text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_password_reset(code uuid, password text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_password_reset(code uuid, password text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_reset(code uuid, password text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_password_reset(code uuid, password text) IS 'Sets a new password for an account if there was a request to do so before that''s still up to date.';
 
 
 --
--- Name: account_password_reset_request(text, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_password_reset_request(text, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_password_reset_request(email_address text, language text) RETURNS void
@@ -451,17 +451,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_password_reset_request(email_address text, language text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_password_reset_request(email_address text, language text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_password_reset_request(email_address text, language text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_reset_request(email_address text, language text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_password_reset_request(email_address text, language text) IS 'Sets a new password reset verification code for an account.';
 
 
 --
--- Name: account_registration(text, text, text, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_registration(text, text, text, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_registration(username text, email_address text, password text, language text) RETURNS uuid
@@ -514,17 +514,17 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.account_registration(username text, email_address text, password text, language text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_registration(username text, email_address text, password text, language text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_registration(username text, email_address text, password text, language text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_registration(username text, email_address text, password text, language text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_registration(username text, email_address text, password text, language text) IS 'Creates a contact and registers an account referencing it.';
 
 
 --
--- Name: account_registration_refresh(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_registration_refresh(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) RETURNS void
@@ -564,17 +564,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) OWNER TO postgres;
+ALTER FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) OWNER TO ci;
 
 --
--- Name: FUNCTION account_registration_refresh(account_id uuid, language text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_registration_refresh(account_id uuid, language text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) IS 'Refreshes an account''s email address verification validity period.';
 
 
 --
--- Name: account_upload_quota_bytes(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: account_upload_quota_bytes(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.account_upload_quota_bytes() RETURNS bigint
@@ -586,17 +586,17 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.account_upload_quota_bytes() OWNER TO postgres;
+ALTER FUNCTION maevsi.account_upload_quota_bytes() OWNER TO ci;
 
 --
--- Name: FUNCTION account_upload_quota_bytes(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_upload_quota_bytes(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.account_upload_quota_bytes() IS 'Gets the total upload quota in bytes for the invoking account.';
 
 
 --
--- Name: achievement_unlock(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: achievement_unlock(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.achievement_unlock(code uuid, alias text) RETURNS uuid
@@ -638,17 +638,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.achievement_unlock(code uuid, alias text) OWNER TO postgres;
+ALTER FUNCTION maevsi.achievement_unlock(code uuid, alias text) OWNER TO ci;
 
 --
--- Name: FUNCTION achievement_unlock(code uuid, alias text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION achievement_unlock(code uuid, alias text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.achievement_unlock(code uuid, alias text) IS 'Inserts an achievement unlock for the user that gave an existing achievement code.';
 
 
 --
--- Name: authenticate(text, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: authenticate(text, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.authenticate(username text, password text) RETURNS maevsi.jwt
@@ -711,10 +711,10 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.authenticate(username text, password text) OWNER TO postgres;
+ALTER FUNCTION maevsi.authenticate(username text, password text) OWNER TO ci;
 
 --
--- Name: FUNCTION authenticate(username text, password text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION authenticate(username text, password text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.authenticate(username text, password text) IS 'Creates a JWT token that will securely identify an account and give it certain permissions.';
@@ -725,7 +725,7 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: event; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event (
@@ -753,17 +753,17 @@ CREATE TABLE maevsi.event (
 );
 
 
-ALTER TABLE maevsi.event OWNER TO postgres;
+ALTER TABLE maevsi.event OWNER TO ci;
 
 --
--- Name: TABLE event; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event IS 'An event.';
 
 
 --
--- Name: COLUMN event.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.id IS '@omit create,update
@@ -771,98 +771,98 @@ The event''s internal id.';
 
 
 --
--- Name: COLUMN event.author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.author_account_id IS 'The event author''s id.';
 
 
 --
--- Name: COLUMN event.description; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.description; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.description IS 'The event''s description.';
 
 
 --
--- Name: COLUMN event."end"; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event."end"; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event."end" IS 'The event''s end date and time, with timezone.';
 
 
 --
--- Name: COLUMN event.invitee_count_maximum; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.invitee_count_maximum; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.invitee_count_maximum IS 'The event''s maximum invitee count.';
 
 
 --
--- Name: COLUMN event.is_archived; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.is_archived; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.is_archived IS 'Indicates whether the event is archived.';
 
 
 --
--- Name: COLUMN event.is_in_person; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.is_in_person; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.is_in_person IS 'Indicates whether the event takes place in person.';
 
 
 --
--- Name: COLUMN event.is_remote; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.is_remote; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.is_remote IS 'Indicates whether the event takes place remotely.';
 
 
 --
--- Name: COLUMN event.location; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.location; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.location IS 'The event''s location as it can be shown on a map.';
 
 
 --
--- Name: COLUMN event.name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.name; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.name IS 'The event''s name.';
 
 
 --
--- Name: COLUMN event.slug; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.slug; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.slug IS 'The event''s name, slugified.';
 
 
 --
--- Name: COLUMN event.start; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.start; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.start IS 'The event''s start date and time, with timezone.';
 
 
 --
--- Name: COLUMN event.url; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.url; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.url IS 'The event''s unified resource locator.';
 
 
 --
--- Name: COLUMN event.visibility; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.visibility; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.visibility IS 'The event''s visibility.';
 
 
 --
--- Name: COLUMN event.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event.created_at IS '@omit create,update
@@ -870,7 +870,7 @@ Timestamp of when the event was created, defaults to the current timestamp.';
 
 
 --
--- Name: event_delete(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: event_delete(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.event_delete(id uuid, password text) RETURNS maevsi.event
@@ -902,17 +902,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.event_delete(id uuid, password text) OWNER TO postgres;
+ALTER FUNCTION maevsi.event_delete(id uuid, password text) OWNER TO ci;
 
 --
--- Name: FUNCTION event_delete(id uuid, password text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_delete(id uuid, password text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.event_delete(id uuid, password text) IS 'Allows to delete an event.';
 
 
 --
--- Name: event_invitee_count_maximum(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: event_invitee_count_maximum(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) RETURNS integer
@@ -946,17 +946,17 @@ END
 $_$;
 
 
-ALTER FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION event_invitee_count_maximum(event_id uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_invitee_count_maximum(event_id uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) IS 'Add a function that returns the maximum invitee count of an accessible event.';
 
 
 --
--- Name: event_is_existing(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: event_is_existing(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text) RETURNS boolean
@@ -972,17 +972,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text) OWNER TO postgres;
+ALTER FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text) OWNER TO ci;
 
 --
--- Name: FUNCTION event_is_existing(author_account_id uuid, slug text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_is_existing(author_account_id uuid, slug text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text) IS 'Shows if an event exists.';
 
 
 --
--- Name: event_unlock(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: event_unlock(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.event_unlock(invitation_id uuid) RETURNS maevsi.event_unlock_response
@@ -1041,17 +1041,17 @@ BEGIN
 END $_$;
 
 
-ALTER FUNCTION maevsi.event_unlock(invitation_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.event_unlock(invitation_id uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION event_unlock(invitation_id uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_unlock(invitation_id uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.event_unlock(invitation_id uuid) IS 'Assigns an invitation to the current session.';
 
 
 --
--- Name: events_organized(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: events_organized(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.events_organized() RETURNS TABLE(event_id uuid)
@@ -1067,17 +1067,17 @@ END
 $$;
 
 
-ALTER FUNCTION maevsi.events_organized() OWNER TO postgres;
+ALTER FUNCTION maevsi.events_organized() OWNER TO ci;
 
 --
--- Name: FUNCTION events_organized(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION events_organized(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.events_organized() IS 'Add a function that returns all event ids for which the invoker is the author.';
 
 
 --
--- Name: invitation_claim_array(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: invitation_claim_array(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.invitation_claim_array() RETURNS uuid[]
@@ -1120,17 +1120,17 @@ END
 $$;
 
 
-ALTER FUNCTION maevsi.invitation_claim_array() OWNER TO postgres;
+ALTER FUNCTION maevsi.invitation_claim_array() OWNER TO ci;
 
 --
--- Name: FUNCTION invitation_claim_array(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitation_claim_array(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.invitation_claim_array() IS 'Returns the current invitation claims as UUID array.';
 
 
 --
--- Name: invitation_contact_ids(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: invitation_contact_ids(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.invitation_contact_ids() RETURNS TABLE(contact_id uuid)
@@ -1169,17 +1169,17 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.invitation_contact_ids() OWNER TO postgres;
+ALTER FUNCTION maevsi.invitation_contact_ids() OWNER TO ci;
 
 --
--- Name: FUNCTION invitation_contact_ids(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitation_contact_ids(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.invitation_contact_ids() IS 'Returns contact ids that are accessible through invitations.';
 
 
 --
--- Name: invite(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: invite(uuid, text); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.invite(invitation_id uuid, language text) RETURNS void
@@ -1259,17 +1259,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.invite(invitation_id uuid, language text) OWNER TO postgres;
+ALTER FUNCTION maevsi.invite(invitation_id uuid, language text) OWNER TO ci;
 
 --
--- Name: FUNCTION invite(invitation_id uuid, language text); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invite(invitation_id uuid, language text); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.invite(invitation_id uuid, language text) IS 'Adds a notification for the invitation channel.';
 
 
 --
--- Name: invitee_count(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: invitee_count(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.invitee_count(event_id uuid) RETURNS integer
@@ -1281,17 +1281,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.invitee_count(event_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.invitee_count(event_id uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION invitee_count(event_id uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitee_count(event_id uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.invitee_count(event_id uuid) IS 'Returns the invitee count for an event.';
 
 
 --
--- Name: invoker_account_id(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: invoker_account_id(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.invoker_account_id() RETURNS uuid
@@ -1303,17 +1303,17 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.invoker_account_id() OWNER TO postgres;
+ALTER FUNCTION maevsi.invoker_account_id() OWNER TO ci;
 
 --
--- Name: FUNCTION invoker_account_id(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invoker_account_id(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.invoker_account_id() IS 'Returns the session''s account id.';
 
 
 --
--- Name: jwt_refresh(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: jwt_refresh(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.jwt_refresh(jwt_id uuid) RETURNS maevsi.jwt
@@ -1350,17 +1350,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.jwt_refresh(jwt_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.jwt_refresh(jwt_id uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION jwt_refresh(jwt_id uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION jwt_refresh(jwt_id uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.jwt_refresh(jwt_id uuid) IS 'Refreshes a JWT.';
 
 
 --
--- Name: legal_term_change(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: legal_term_change(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.legal_term_change() RETURNS trigger
@@ -1373,10 +1373,10 @@ END;
 $$;
 
 
-ALTER FUNCTION maevsi.legal_term_change() OWNER TO postgres;
+ALTER FUNCTION maevsi.legal_term_change() OWNER TO ci;
 
 --
--- Name: notification_acknowledge(uuid, boolean); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: notification_acknowledge(uuid, boolean); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) RETURNS void
@@ -1392,17 +1392,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) OWNER TO postgres;
+ALTER FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) OWNER TO ci;
 
 --
--- Name: FUNCTION notification_acknowledge(id uuid, is_acknowledged boolean); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION notification_acknowledge(id uuid, is_acknowledged boolean); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) IS 'Allows to set the acknowledgement state of a notification.';
 
 
 --
--- Name: profile_picture_set(uuid); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: profile_picture_set(uuid); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.profile_picture_set(upload_id uuid) RETURNS void
@@ -1421,17 +1421,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.profile_picture_set(upload_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi.profile_picture_set(upload_id uuid) OWNER TO ci;
 
 --
--- Name: FUNCTION profile_picture_set(upload_id uuid); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION profile_picture_set(upload_id uuid); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.profile_picture_set(upload_id uuid) IS 'Sets the picture with the given upload id as the invoker''s profile picture.';
 
 
 --
--- Name: trigger_contact_update_account_id(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: trigger_contact_update_account_id(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.trigger_contact_update_account_id() RETURNS trigger
@@ -1466,17 +1466,17 @@ CREATE FUNCTION maevsi.trigger_contact_update_account_id() RETURNS trigger
 $$;
 
 
-ALTER FUNCTION maevsi.trigger_contact_update_account_id() OWNER TO postgres;
+ALTER FUNCTION maevsi.trigger_contact_update_account_id() OWNER TO ci;
 
 --
--- Name: FUNCTION trigger_contact_update_account_id(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION trigger_contact_update_account_id(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.trigger_contact_update_account_id() IS 'Prevents invalid updates to contacts.';
 
 
 --
--- Name: trigger_invitation_update(); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: trigger_invitation_update(); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.trigger_invitation_update() RETURNS trigger
@@ -1517,17 +1517,17 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi.trigger_invitation_update() OWNER TO postgres;
+ALTER FUNCTION maevsi.trigger_invitation_update() OWNER TO ci;
 
 --
--- Name: FUNCTION trigger_invitation_update(); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION trigger_invitation_update(); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.trigger_invitation_update() IS 'Checks if the caller has permissions to alter the desired columns.';
 
 
 --
--- Name: upload; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: upload; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.upload (
@@ -1543,17 +1543,17 @@ CREATE TABLE maevsi.upload (
 );
 
 
-ALTER TABLE maevsi.upload OWNER TO postgres;
+ALTER TABLE maevsi.upload OWNER TO ci;
 
 --
--- Name: TABLE upload; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE upload; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.upload IS 'An upload.';
 
 
 --
--- Name: COLUMN upload.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.id IS '@omit create,update
@@ -1561,42 +1561,42 @@ The upload''s internal id.';
 
 
 --
--- Name: COLUMN upload.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.account_id IS 'The uploader''s account id.';
 
 
 --
--- Name: COLUMN upload.name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.name; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.name IS 'The name of the uploaded file.';
 
 
 --
--- Name: COLUMN upload.size_byte; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.size_byte; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.size_byte IS 'The upload''s size in bytes.';
 
 
 --
--- Name: COLUMN upload.storage_key; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.storage_key; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.storage_key IS 'The upload''s storage key.';
 
 
 --
--- Name: COLUMN upload.type; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.type; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.type IS 'The type of the uploaded file, default is ''image''.';
 
 
 --
--- Name: COLUMN upload.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN upload.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.upload.created_at IS '@omit create,update
@@ -1604,7 +1604,7 @@ Timestamp of when the upload was created, defaults to the current timestamp.';
 
 
 --
--- Name: upload_create(bigint); Type: FUNCTION; Schema: maevsi; Owner: postgres
+-- Name: upload_create(bigint); Type: FUNCTION; Schema: maevsi; Owner: ci
 --
 
 CREATE FUNCTION maevsi.upload_create(size_byte bigint) RETURNS maevsi.upload
@@ -1634,17 +1634,17 @@ END;
 $_$;
 
 
-ALTER FUNCTION maevsi.upload_create(size_byte bigint) OWNER TO postgres;
+ALTER FUNCTION maevsi.upload_create(size_byte bigint) OWNER TO ci;
 
 --
--- Name: FUNCTION upload_create(size_byte bigint); Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION upload_create(size_byte bigint); Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi.upload_create(size_byte bigint) IS 'Creates an upload with the given size if quota is available.';
 
 
 --
--- Name: account_block_ids(); Type: FUNCTION; Schema: maevsi_private; Owner: postgres
+-- Name: account_block_ids(); Type: FUNCTION; Schema: maevsi_private; Owner: ci
 --
 
 CREATE FUNCTION maevsi_private.account_block_ids() RETURNS TABLE(id uuid)
@@ -1665,17 +1665,17 @@ END
 $$;
 
 
-ALTER FUNCTION maevsi_private.account_block_ids() OWNER TO postgres;
+ALTER FUNCTION maevsi_private.account_block_ids() OWNER TO ci;
 
 --
--- Name: FUNCTION account_block_ids(); Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_block_ids(); Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi_private.account_block_ids() IS 'Returns all account ids being blocked by the invoker and all accounts that blocked the invoker.';
 
 
 --
--- Name: account_email_address_verification_valid_until(); Type: FUNCTION; Schema: maevsi_private; Owner: postgres
+-- Name: account_email_address_verification_valid_until(); Type: FUNCTION; Schema: maevsi_private; Owner: ci
 --
 
 CREATE FUNCTION maevsi_private.account_email_address_verification_valid_until() RETURNS trigger
@@ -1695,17 +1695,17 @@ CREATE FUNCTION maevsi_private.account_email_address_verification_valid_until() 
 $$;
 
 
-ALTER FUNCTION maevsi_private.account_email_address_verification_valid_until() OWNER TO postgres;
+ALTER FUNCTION maevsi_private.account_email_address_verification_valid_until() OWNER TO ci;
 
 --
--- Name: FUNCTION account_email_address_verification_valid_until(); Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_email_address_verification_valid_until(); Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi_private.account_email_address_verification_valid_until() IS 'Sets the valid until column of the email address verification to it''s default value.';
 
 
 --
--- Name: account_password_reset_verification_valid_until(); Type: FUNCTION; Schema: maevsi_private; Owner: postgres
+-- Name: account_password_reset_verification_valid_until(); Type: FUNCTION; Schema: maevsi_private; Owner: ci
 --
 
 CREATE FUNCTION maevsi_private.account_password_reset_verification_valid_until() RETURNS trigger
@@ -1725,17 +1725,17 @@ CREATE FUNCTION maevsi_private.account_password_reset_verification_valid_until()
 $$;
 
 
-ALTER FUNCTION maevsi_private.account_password_reset_verification_valid_until() OWNER TO postgres;
+ALTER FUNCTION maevsi_private.account_password_reset_verification_valid_until() OWNER TO ci;
 
 --
--- Name: FUNCTION account_password_reset_verification_valid_until(); Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_password_reset_verification_valid_until(); Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi_private.account_password_reset_verification_valid_until() IS 'Sets the valid until column of the email address verification to it''s default value.';
 
 
 --
--- Name: events_invited(); Type: FUNCTION; Schema: maevsi_private; Owner: postgres
+-- Name: events_invited(); Type: FUNCTION; Schema: maevsi_private; Owner: ci
 --
 
 CREATE FUNCTION maevsi_private.events_invited() RETURNS TABLE(event_id uuid)
@@ -1769,17 +1769,17 @@ END
 $$;
 
 
-ALTER FUNCTION maevsi_private.events_invited() OWNER TO postgres;
+ALTER FUNCTION maevsi_private.events_invited() OWNER TO ci;
 
 --
--- Name: FUNCTION events_invited(); Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION events_invited(); Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON FUNCTION maevsi_private.events_invited() IS 'Add a function that returns all event ids for which the invoker is invited.';
 
 
 --
--- Name: account_block_create(uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: account_block_create(uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.account_block_create(_author_account_id uuid, _blocked_account_id uuid) RETURNS uuid
@@ -1795,16 +1795,16 @@ BEGIN
   VALUES (_author_account_id, _blocked_Account_id)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.account_block_create(_author_account_id uuid, _blocked_account_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.account_block_create(_author_account_id uuid, _blocked_account_id uuid) OWNER TO ci;
 
 --
--- Name: account_block_remove(uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: account_block_remove(uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.account_block_remove(_author_account_id uuid, _blocked_account_id uuid) RETURNS void
@@ -1818,10 +1818,10 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.account_block_remove(_author_account_id uuid, _blocked_account_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.account_block_remove(_author_account_id uuid, _blocked_account_id uuid) OWNER TO ci;
 
 --
--- Name: account_create(text, text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: account_create(text, text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.account_create(_username text, _email text) RETURNS uuid
@@ -1843,10 +1843,10 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.account_create(_username text, _email text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.account_create(_username text, _email text) OWNER TO ci;
 
 --
--- Name: account_remove(text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: account_remove(text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.account_remove(_username text) RETURNS void
@@ -1866,15 +1866,15 @@ BEGIN
 
     PERFORM maevsi.account_delete('password');
 
-    SET LOCAL role = 'postgres';
+    PERFORM maevsi_test.set_local_superuser();
   END IF;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.account_remove(_username text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.account_remove(_username text) OWNER TO ci;
 
 --
--- Name: contact_create(uuid, text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: contact_create(uuid, text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.contact_create(_author_account_id uuid, _email_address text) RETURNS uuid
@@ -1897,16 +1897,16 @@ BEGIN
     UPDATE maevsi.contact SET account_id = _account_id WHERE id = _id;
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.contact_create(_author_account_id uuid, _email_address text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.contact_create(_author_account_id uuid, _email_address text) OWNER TO ci;
 
 --
--- Name: contact_select_by_account_id(uuid); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: contact_select_by_account_id(uuid); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.contact_select_by_account_id(_account_id uuid) RETURNS uuid
@@ -1923,10 +1923,10 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.contact_select_by_account_id(_account_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.contact_select_by_account_id(_account_id uuid) OWNER TO ci;
 
 --
--- Name: contact_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: contact_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.contact_test(_test_case text, _account_id uuid, _expected_result uuid[]) RETURNS void
@@ -1951,14 +1951,14 @@ BEGIN
     RAISE EXCEPTION 'some contact is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$;
 
 
-ALTER FUNCTION maevsi_test.contact_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.contact_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO ci;
 
 --
--- Name: event_category_create(text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: event_category_create(text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.event_category_create(_category text) RETURNS void
@@ -1969,10 +1969,10 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.event_category_create(_category text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.event_category_create(_category text) OWNER TO ci;
 
 --
--- Name: event_category_mapping_create(uuid, uuid, text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: event_category_mapping_create(uuid, uuid, text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text) RETURNS void
@@ -1985,14 +1985,14 @@ BEGIN
   INSERT INTO maevsi.event_category_mapping(event_id, category)
   VALUES (_event_id, _category);
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$;
 
 
-ALTER FUNCTION maevsi_test.event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text) OWNER TO ci;
 
 --
--- Name: event_category_mapping_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: event_category_mapping_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]) RETURNS void
@@ -2015,14 +2015,14 @@ BEGIN
     RAISE EXCEPTION 'some event_category_mappings is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$;
 
 
-ALTER FUNCTION maevsi_test.event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO ci;
 
 --
--- Name: event_create(uuid, text, text, text, text); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: event_create(uuid, text, text, text, text); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text) RETURNS uuid
@@ -2038,16 +2038,16 @@ BEGIN
   VALUES (_author_account_id, _name, _slug, _start::TIMESTAMP WITH TIME ZONE, _visibility::maevsi.event_visibility)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text) OWNER TO ci;
 
 --
--- Name: event_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: event_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.event_test(_test_case text, _account_id uuid, _expected_result uuid[]) RETURNS void
@@ -2070,14 +2070,14 @@ BEGIN
     RAISE EXCEPTION 'some event is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$;
 
 
-ALTER FUNCTION maevsi_test.event_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.event_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO ci;
 
 --
--- Name: invitation_claim_from_account_invitation(uuid); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: invitation_claim_from_account_invitation(uuid); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.invitation_claim_from_account_invitation(_account_id uuid) RETURNS uuid[]
@@ -2111,16 +2111,16 @@ BEGIN
 
   EXECUTE 'SET LOCAL jwt.claims.invitations = ''[' || _text || ']''';
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _result;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.invitation_claim_from_account_invitation(_account_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.invitation_claim_from_account_invitation(_account_id uuid) OWNER TO ci;
 
 --
--- Name: invitation_create(uuid, uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: invitation_create(uuid, uuid, uuid); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid) RETURNS uuid
@@ -2136,16 +2136,16 @@ BEGIN
   VALUES (_contact_id, _event_id)
   RETURNING id INTO _id;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
 
 
-ALTER FUNCTION maevsi_test.invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid) OWNER TO ci;
 
 --
--- Name: invitation_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: invitation_test(text, uuid, uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) RETURNS void
@@ -2168,14 +2168,40 @@ BEGIN
     RAISE EXCEPTION 'some invitation is missing in the query result';
   END IF;
 
-  SET LOCAL role = 'postgres';
+  PERFORM maevsi_test.set_local_superuser();
 END $$;
 
 
-ALTER FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO ci;
 
 --
--- Name: uuid_array_test(text, uuid[], uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: postgres
+-- Name: set_local_superuser(); Type: FUNCTION; Schema: maevsi_test; Owner: ci
+--
+
+CREATE FUNCTION maevsi_test.set_local_superuser() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    _superuser_name TEXT;
+BEGIN
+  SELECT usename INTO _superuser_name
+  FROM pg_user
+  WHERE usesuper = true
+  ORDER BY usename
+  LIMIT 1;
+
+  IF _superuser_name IS NOT NULL THEN
+    EXECUTE format('SET LOCAL role = %I', _superuser_name);
+  ELSE
+    RAISE NOTICE 'No superuser found!';
+  END IF;
+END $$;
+
+
+ALTER FUNCTION maevsi_test.set_local_superuser() OWNER TO ci;
+
+--
+-- Name: uuid_array_test(text, uuid[], uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
 --
 
 CREATE FUNCTION maevsi_test.uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]) RETURNS void
@@ -2192,10 +2218,10 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]) OWNER TO postgres;
+ALTER FUNCTION maevsi_test.uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]) OWNER TO ci;
 
 --
--- Name: account; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: account; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.account (
@@ -2205,31 +2231,31 @@ CREATE TABLE maevsi.account (
 );
 
 
-ALTER TABLE maevsi.account OWNER TO postgres;
+ALTER TABLE maevsi.account OWNER TO ci;
 
 --
--- Name: TABLE account; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE account; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.account IS 'Public account data.';
 
 
 --
--- Name: COLUMN account.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account.id IS 'The account''s internal id.';
 
 
 --
--- Name: COLUMN account.username; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account.username; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account.username IS 'The account''s username.';
 
 
 --
--- Name: account_block; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: account_block; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.account_block (
@@ -2241,10 +2267,10 @@ CREATE TABLE maevsi.account_block (
 );
 
 
-ALTER TABLE maevsi.account_block OWNER TO postgres;
+ALTER TABLE maevsi.account_block OWNER TO ci;
 
 --
--- Name: TABLE account_block; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_block; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.account_block IS '@omit update,delete
@@ -2252,28 +2278,28 @@ Blocking of one account by another.';
 
 
 --
--- Name: COLUMN account_block.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_block.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_block.id IS '@omit create\nThe account blocking''s internal id.';
 
 
 --
--- Name: COLUMN account_block.author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_block.author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_block.author_account_id IS 'The account id of the user who created the blocking.';
 
 
 --
--- Name: COLUMN account_block.blocked_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_block.blocked_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_block.blocked_account_id IS 'The account id of the user who is blocked.';
 
 
 --
--- Name: COLUMN account_block.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_block.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_block.created_at IS '@omit create,update,delete
@@ -2281,7 +2307,7 @@ Timestamp of when the blocking was created.';
 
 
 --
--- Name: account_interest; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: account_interest; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.account_interest (
@@ -2290,31 +2316,31 @@ CREATE TABLE maevsi.account_interest (
 );
 
 
-ALTER TABLE maevsi.account_interest OWNER TO postgres;
+ALTER TABLE maevsi.account_interest OWNER TO ci;
 
 --
--- Name: TABLE account_interest; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_interest; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.account_interest IS 'Event categories a user account is interested in (M:N relationship).';
 
 
 --
--- Name: COLUMN account_interest.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_interest.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_interest.account_id IS 'A user account id.';
 
 
 --
--- Name: COLUMN account_interest.category; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_interest.category; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_interest.category IS 'An event category.';
 
 
 --
--- Name: account_preference_event_size; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.account_preference_event_size (
@@ -2324,31 +2350,31 @@ CREATE TABLE maevsi.account_preference_event_size (
 );
 
 
-ALTER TABLE maevsi.account_preference_event_size OWNER TO postgres;
+ALTER TABLE maevsi.account_preference_event_size OWNER TO ci;
 
 --
--- Name: TABLE account_preference_event_size; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_preference_event_size; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.account_preference_event_size IS 'Table for the user accounts'' preferred event sizes (M:N relationship).';
 
 
 --
--- Name: COLUMN account_preference_event_size.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_preference_event_size.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_preference_event_size.account_id IS 'The account''s internal id.';
 
 
 --
--- Name: COLUMN account_preference_event_size.event_size; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_preference_event_size.event_size; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_preference_event_size.event_size IS 'A preferred event sized';
 
 
 --
--- Name: COLUMN account_preference_event_size.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_preference_event_size.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_preference_event_size.created_at IS '@omit create,update
@@ -2356,7 +2382,7 @@ Timestamp of when the event size preference was created, defaults to the current
 
 
 --
--- Name: account_social_network; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: account_social_network; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.account_social_network (
@@ -2366,38 +2392,38 @@ CREATE TABLE maevsi.account_social_network (
 );
 
 
-ALTER TABLE maevsi.account_social_network OWNER TO postgres;
+ALTER TABLE maevsi.account_social_network OWNER TO ci;
 
 --
--- Name: TABLE account_social_network; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_social_network; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.account_social_network IS 'Links accounts to their social media profiles. Each entry represents a specific social network and associated username for an account.';
 
 
 --
--- Name: COLUMN account_social_network.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_social_network.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_social_network.account_id IS 'The unique identifier of the account.';
 
 
 --
--- Name: COLUMN account_social_network.social_network; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_social_network.social_network; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_social_network.social_network IS 'The social network to which the account is linked.';
 
 
 --
--- Name: COLUMN account_social_network.social_network_username; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN account_social_network.social_network_username; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.account_social_network.social_network_username IS 'The username of the account on the specified social network.';
 
 
 --
--- Name: achievement; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: achievement; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.achievement (
@@ -2409,45 +2435,45 @@ CREATE TABLE maevsi.achievement (
 );
 
 
-ALTER TABLE maevsi.achievement OWNER TO postgres;
+ALTER TABLE maevsi.achievement OWNER TO ci;
 
 --
--- Name: TABLE achievement; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE achievement; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.achievement IS 'Achievements unlocked by users.';
 
 
 --
--- Name: COLUMN achievement.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN achievement.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.achievement.id IS 'The achievement unlock''s internal id.';
 
 
 --
--- Name: COLUMN achievement.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN achievement.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.achievement.account_id IS 'The account which unlocked the achievement.';
 
 
 --
--- Name: COLUMN achievement.achievement; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN achievement.achievement; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.achievement.achievement IS 'The unlock''s achievement.';
 
 
 --
--- Name: COLUMN achievement.level; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN achievement.level; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.achievement.level IS 'The achievement unlock''s level.';
 
 
 --
--- Name: contact; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: contact; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.contact (
@@ -2476,17 +2502,17 @@ CREATE TABLE maevsi.contact (
 );
 
 
-ALTER TABLE maevsi.contact OWNER TO postgres;
+ALTER TABLE maevsi.contact OWNER TO ci;
 
 --
--- Name: TABLE contact; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE contact; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.contact IS 'Contact data.';
 
 
 --
--- Name: COLUMN contact.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.id IS '@omit create,update
@@ -2494,35 +2520,35 @@ The contact''s internal id.';
 
 
 --
--- Name: COLUMN contact.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.account_id IS 'The contact account''s id.';
 
 
 --
--- Name: COLUMN contact.address; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.address; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.address IS 'The contact''s physical address.';
 
 
 --
--- Name: COLUMN contact.author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.author_account_id IS 'The contact author''s id.';
 
 
 --
--- Name: COLUMN contact.email_address; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.email_address; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.email_address IS 'The contact''s email address.';
 
 
 --
--- Name: COLUMN contact.email_address_hash; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.email_address_hash; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.email_address_hash IS '@omit create,update
@@ -2530,56 +2556,56 @@ The contact''s email address''s md5 hash.';
 
 
 --
--- Name: COLUMN contact.first_name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.first_name; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.first_name IS 'The contact''s first name.';
 
 
 --
--- Name: COLUMN contact.language; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.language; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.language IS 'The contact''s language.';
 
 
 --
--- Name: COLUMN contact.last_name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.last_name; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.last_name IS 'The contact''s last name.';
 
 
 --
--- Name: COLUMN contact.nickname; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.nickname; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.nickname IS 'The contact''s nickname.';
 
 
 --
--- Name: COLUMN contact.phone_number; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.phone_number; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.phone_number IS 'The contact''s international phone number in E.164 format (https://wikipedia.org/wiki/E.164).';
 
 
 --
--- Name: COLUMN contact.timezone; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.timezone; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.timezone IS 'The contact''s ISO 8601 timezone, e.g. `+02:00`, `-05:30` or `Z`.';
 
 
 --
--- Name: COLUMN contact.url; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.url; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.url IS 'The contact''s website url.';
 
 
 --
--- Name: COLUMN contact.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN contact.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.contact.created_at IS '@omit create,update
@@ -2587,7 +2613,7 @@ Timestamp of when the contact was created, defaults to the current timestamp.';
 
 
 --
--- Name: event_category; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_category; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_category (
@@ -2595,24 +2621,24 @@ CREATE TABLE maevsi.event_category (
 );
 
 
-ALTER TABLE maevsi.event_category OWNER TO postgres;
+ALTER TABLE maevsi.event_category OWNER TO ci;
 
 --
--- Name: TABLE event_category; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_category; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_category IS 'Event categories.';
 
 
 --
--- Name: COLUMN event_category.category; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_category.category; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_category.category IS 'A category name.';
 
 
 --
--- Name: event_category_mapping; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_category_mapping (
@@ -2621,31 +2647,31 @@ CREATE TABLE maevsi.event_category_mapping (
 );
 
 
-ALTER TABLE maevsi.event_category_mapping OWNER TO postgres;
+ALTER TABLE maevsi.event_category_mapping OWNER TO ci;
 
 --
--- Name: TABLE event_category_mapping; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_category_mapping; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_category_mapping IS 'Mapping events to categories (M:N relationship).';
 
 
 --
--- Name: COLUMN event_category_mapping.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_category_mapping.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_category_mapping.event_id IS 'An event id.';
 
 
 --
--- Name: COLUMN event_category_mapping.category; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_category_mapping.category; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_category_mapping.category IS 'A category name.';
 
 
 --
--- Name: event_favourite; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_favourite; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_favourite (
@@ -2654,31 +2680,31 @@ CREATE TABLE maevsi.event_favourite (
 );
 
 
-ALTER TABLE maevsi.event_favourite OWNER TO postgres;
+ALTER TABLE maevsi.event_favourite OWNER TO ci;
 
 --
--- Name: TABLE event_favourite; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_favourite; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_favourite IS 'The user accounts'' favourite events.';
 
 
 --
--- Name: COLUMN event_favourite.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_favourite.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_favourite.account_id IS 'A user account id.';
 
 
 --
--- Name: COLUMN event_favourite.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_favourite.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_favourite.event_id IS 'The ID of an event which the user marked as a favourite.';
 
 
 --
--- Name: event_group; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_group; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_group (
@@ -2695,17 +2721,17 @@ CREATE TABLE maevsi.event_group (
 );
 
 
-ALTER TABLE maevsi.event_group OWNER TO postgres;
+ALTER TABLE maevsi.event_group OWNER TO ci;
 
 --
--- Name: TABLE event_group; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_group; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_group IS 'A group of events.';
 
 
 --
--- Name: COLUMN event_group.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.id IS '@omit create,update
@@ -2713,35 +2739,35 @@ The event group''s internal id.';
 
 
 --
--- Name: COLUMN event_group.author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.author_account_id IS 'The event group author''s id.';
 
 
 --
--- Name: COLUMN event_group.description; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.description; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.description IS 'The event group''s description.';
 
 
 --
--- Name: COLUMN event_group.is_archived; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.is_archived; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.is_archived IS 'Indicates whether the event group is archived.';
 
 
 --
--- Name: COLUMN event_group.name; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.name; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.name IS 'The event group''s name.';
 
 
 --
--- Name: COLUMN event_group.slug; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.slug; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.slug IS '@omit create,update
@@ -2749,7 +2775,7 @@ The event group''s name, slugified.';
 
 
 --
--- Name: COLUMN event_group.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_group.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_group.created_at IS '@omit create,update
@@ -2757,7 +2783,7 @@ Timestamp of when the event group was created, defaults to the current timestamp
 
 
 --
--- Name: event_grouping; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_grouping; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_grouping (
@@ -2767,17 +2793,17 @@ CREATE TABLE maevsi.event_grouping (
 );
 
 
-ALTER TABLE maevsi.event_grouping OWNER TO postgres;
+ALTER TABLE maevsi.event_grouping OWNER TO ci;
 
 --
--- Name: TABLE event_grouping; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_grouping; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_grouping IS 'A bidirectional mapping between an event and an event group.';
 
 
 --
--- Name: COLUMN event_grouping.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_grouping.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_grouping.id IS '@omit create,update
@@ -2785,21 +2811,21 @@ The event grouping''s internal id.';
 
 
 --
--- Name: COLUMN event_grouping.event_group_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_grouping.event_group_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_grouping.event_group_id IS 'The event grouping''s internal event group id.';
 
 
 --
--- Name: COLUMN event_grouping.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_grouping.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_grouping.event_id IS 'The event grouping''s internal event id.';
 
 
 --
--- Name: event_recommendation; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_recommendation (
@@ -2810,45 +2836,45 @@ CREATE TABLE maevsi.event_recommendation (
 );
 
 
-ALTER TABLE maevsi.event_recommendation OWNER TO postgres;
+ALTER TABLE maevsi.event_recommendation OWNER TO ci;
 
 --
--- Name: TABLE event_recommendation; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_recommendation; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_recommendation IS 'Events recommended to a user account (M:N relationship).';
 
 
 --
--- Name: COLUMN event_recommendation.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_recommendation.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_recommendation.account_id IS 'A user account id.';
 
 
 --
--- Name: COLUMN event_recommendation.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_recommendation.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_recommendation.event_id IS 'The predicted score of the recommendation.';
 
 
 --
--- Name: COLUMN event_recommendation.score; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_recommendation.score; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_recommendation.score IS 'An event id.';
 
 
 --
--- Name: COLUMN event_recommendation.predicted_score; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_recommendation.predicted_score; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_recommendation.predicted_score IS 'The score of the recommendation.';
 
 
 --
--- Name: event_upload; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: event_upload; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.event_upload (
@@ -2858,17 +2884,17 @@ CREATE TABLE maevsi.event_upload (
 );
 
 
-ALTER TABLE maevsi.event_upload OWNER TO postgres;
+ALTER TABLE maevsi.event_upload OWNER TO ci;
 
 --
--- Name: TABLE event_upload; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_upload; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.event_upload IS 'An assignment of an uploaded content (e.g. an image) to an event.';
 
 
 --
--- Name: COLUMN event_upload.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_upload.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_upload.id IS '@omit create,update
@@ -2876,7 +2902,7 @@ The event''s internal id for which the invitation is valid.';
 
 
 --
--- Name: COLUMN event_upload.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_upload.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_upload.event_id IS '@omit update
@@ -2884,7 +2910,7 @@ The event''s internal id for which the invitation is valid.';
 
 
 --
--- Name: COLUMN event_upload.upload_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN event_upload.upload_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.event_upload.upload_id IS '@omit update
@@ -2892,7 +2918,7 @@ The internal id of the uploaded content.';
 
 
 --
--- Name: invitation; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: invitation; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.invitation (
@@ -2907,17 +2933,17 @@ CREATE TABLE maevsi.invitation (
 );
 
 
-ALTER TABLE maevsi.invitation OWNER TO postgres;
+ALTER TABLE maevsi.invitation OWNER TO ci;
 
 --
--- Name: TABLE invitation; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE invitation; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.invitation IS 'An invitation for a contact. A bidirectional mapping between an event and a contact.';
 
 
 --
--- Name: COLUMN invitation.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.id IS '@omit create,update
@@ -2925,35 +2951,35 @@ The invitations''s internal id.';
 
 
 --
--- Name: COLUMN invitation.contact_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.contact_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.contact_id IS 'The contact''s internal id for which the invitation is valid.';
 
 
 --
--- Name: COLUMN invitation.event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.event_id IS 'The event''s internal id for which the invitation is valid.';
 
 
 --
--- Name: COLUMN invitation.feedback; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.feedback; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.feedback IS 'The invitation''s general feedback status.';
 
 
 --
--- Name: COLUMN invitation.feedback_paper; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.feedback_paper; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.feedback_paper IS 'The invitation''s paper feedback status.';
 
 
 --
--- Name: COLUMN invitation.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.created_at IS '@omit create,update
@@ -2961,7 +2987,7 @@ Timestamp of when the invitation was created, defaults to the current timestamp.
 
 
 --
--- Name: COLUMN invitation.updated_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.updated_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.updated_at IS '@omit create,update
@@ -2969,7 +2995,7 @@ Timestamp of when the invitation was last updated.';
 
 
 --
--- Name: COLUMN invitation.updated_by; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN invitation.updated_by; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.invitation.updated_by IS '@omit create,update
@@ -2977,7 +3003,7 @@ The id of the account which last updated the invitation. `NULL` if the invitatio
 
 
 --
--- Name: invitation_flat; Type: VIEW; Schema: maevsi; Owner: postgres
+-- Name: invitation_flat; Type: VIEW; Schema: maevsi; Owner: ci
 --
 
 CREATE VIEW maevsi.invitation_flat WITH (security_invoker='true') AS
@@ -3015,17 +3041,17 @@ CREATE VIEW maevsi.invitation_flat WITH (security_invoker='true') AS
      JOIN maevsi.event ON ((invitation.event_id = event.id)));
 
 
-ALTER VIEW maevsi.invitation_flat OWNER TO postgres;
+ALTER VIEW maevsi.invitation_flat OWNER TO ci;
 
 --
--- Name: VIEW invitation_flat; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: VIEW invitation_flat; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON VIEW maevsi.invitation_flat IS 'View returning flattened invitations.';
 
 
 --
--- Name: legal_term; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: legal_term; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.legal_term (
@@ -3040,10 +3066,10 @@ CREATE TABLE maevsi.legal_term (
 );
 
 
-ALTER TABLE maevsi.legal_term OWNER TO postgres;
+ALTER TABLE maevsi.legal_term OWNER TO ci;
 
 --
--- Name: TABLE legal_term; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE legal_term; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.legal_term IS '@omit create,update,delete
@@ -3051,42 +3077,42 @@ Legal terms like privacy policies or terms of service.';
 
 
 --
--- Name: COLUMN legal_term.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term.id IS 'Unique identifier for each legal term.';
 
 
 --
--- Name: COLUMN legal_term.language; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term.language; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term.language IS 'Language code in ISO 639-1 format with optional region (e.g., `en` for English, `en_GB` for British English)';
 
 
 --
--- Name: COLUMN legal_term.term; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term.term; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term.term IS 'Text of the legal term. Markdown is expected to be used. It must be non-empty and cannot exceed 500,000 characters.';
 
 
 --
--- Name: COLUMN legal_term.version; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term.version; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term.version IS 'Semantic versioning string to track changes to the legal terms (format: `X.Y.Z`).';
 
 
 --
--- Name: COLUMN legal_term.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term.created_at IS 'Timestamp when the term was created. Set to the current time by default.';
 
 
 --
--- Name: legal_term_acceptance; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.legal_term_acceptance (
@@ -3097,17 +3123,17 @@ CREATE TABLE maevsi.legal_term_acceptance (
 );
 
 
-ALTER TABLE maevsi.legal_term_acceptance OWNER TO postgres;
+ALTER TABLE maevsi.legal_term_acceptance OWNER TO ci;
 
 --
--- Name: TABLE legal_term_acceptance; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE legal_term_acceptance; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.legal_term_acceptance IS '@omit update,delete\nTracks each user account''s acceptance of legal terms and conditions.';
 
 
 --
--- Name: COLUMN legal_term_acceptance.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term_acceptance.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term_acceptance.id IS '@omit create
@@ -3115,21 +3141,21 @@ Unique identifier for this legal term acceptance record. Automatically generated
 
 
 --
--- Name: COLUMN legal_term_acceptance.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term_acceptance.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term_acceptance.account_id IS 'The user account ID that accepted the legal terms. If the account is deleted, this acceptance record will also be deleted.';
 
 
 --
--- Name: COLUMN legal_term_acceptance.legal_term_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term_acceptance.legal_term_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term_acceptance.legal_term_id IS 'The ID of the legal terms that were accepted. Deletion of these legal terms is restricted while they are still referenced in this table.';
 
 
 --
--- Name: COLUMN legal_term_acceptance.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN legal_term_acceptance.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.legal_term_acceptance.created_at IS '@omit create
@@ -3137,7 +3163,7 @@ Timestamp showing when the legal terms were accepted, set automatically at the t
 
 
 --
--- Name: profile_picture; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: profile_picture; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.profile_picture (
@@ -3147,17 +3173,17 @@ CREATE TABLE maevsi.profile_picture (
 );
 
 
-ALTER TABLE maevsi.profile_picture OWNER TO postgres;
+ALTER TABLE maevsi.profile_picture OWNER TO ci;
 
 --
--- Name: TABLE profile_picture; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE profile_picture; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.profile_picture IS 'Mapping of account ids to upload ids.';
 
 
 --
--- Name: COLUMN profile_picture.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN profile_picture.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.profile_picture.id IS '@omit create,update
@@ -3165,21 +3191,21 @@ The profile picture''s internal id.';
 
 
 --
--- Name: COLUMN profile_picture.account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN profile_picture.account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.profile_picture.account_id IS 'The account''s id.';
 
 
 --
--- Name: COLUMN profile_picture.upload_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN profile_picture.upload_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.profile_picture.upload_id IS 'The upload''s id.';
 
 
 --
--- Name: report; Type: TABLE; Schema: maevsi; Owner: postgres
+-- Name: report; Type: TABLE; Schema: maevsi; Owner: ci
 --
 
 CREATE TABLE maevsi.report (
@@ -3195,10 +3221,10 @@ CREATE TABLE maevsi.report (
 );
 
 
-ALTER TABLE maevsi.report OWNER TO postgres;
+ALTER TABLE maevsi.report OWNER TO ci;
 
 --
--- Name: TABLE report; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: TABLE report; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON TABLE maevsi.report IS '@omit update,delete
@@ -3206,7 +3232,7 @@ Stores reports made by users on other users, events, or uploads for moderation p
 
 
 --
--- Name: COLUMN report.id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.id IS '@omit create
@@ -3214,42 +3240,42 @@ Unique identifier for the report, generated randomly using UUIDs.';
 
 
 --
--- Name: COLUMN report.author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.author_account_id IS 'The ID of the user who created the report.';
 
 
 --
--- Name: COLUMN report.reason; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.reason; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.reason IS 'The reason for the report, provided by the reporting user. Must be non-empty and less than 2000 characters.';
 
 
 --
--- Name: COLUMN report.target_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.target_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.target_account_id IS 'The ID of the account being reported, if applicable.';
 
 
 --
--- Name: COLUMN report.target_event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.target_event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.target_event_id IS 'The ID of the event being reported, if applicable.';
 
 
 --
--- Name: COLUMN report.target_upload_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.target_upload_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.target_upload_id IS 'The ID of the upload being reported, if applicable.';
 
 
 --
--- Name: COLUMN report.created_at; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: COLUMN report.created_at; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi.report.created_at IS '@omit create
@@ -3257,21 +3283,21 @@ Timestamp of when the report was created, defaults to the current timestamp.';
 
 
 --
--- Name: CONSTRAINT report_check ON report; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: CONSTRAINT report_check ON report; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON CONSTRAINT report_check ON maevsi.report IS 'Ensures that the report targets exactly one element (account, event, or upload).';
 
 
 --
--- Name: CONSTRAINT report_reason_check ON report; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: CONSTRAINT report_reason_check ON report; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON CONSTRAINT report_reason_check ON maevsi.report IS 'Ensures the reason field contains between 1 and 2000 characters.';
 
 
 --
--- Name: account; Type: TABLE; Schema: maevsi_private; Owner: postgres
+-- Name: account; Type: TABLE; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TABLE maevsi_private.account (
@@ -3290,94 +3316,94 @@ CREATE TABLE maevsi_private.account (
 );
 
 
-ALTER TABLE maevsi_private.account OWNER TO postgres;
+ALTER TABLE maevsi_private.account OWNER TO ci;
 
 --
--- Name: TABLE account; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: TABLE account; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON TABLE maevsi_private.account IS 'Private account data.';
 
 
 --
--- Name: COLUMN account.id; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.id; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.id IS 'The account''s internal id.';
 
 
 --
--- Name: COLUMN account.birth_date; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.birth_date; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.birth_date IS 'The account owner''s date of birth.';
 
 
 --
--- Name: COLUMN account.email_address; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.email_address; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.email_address IS 'The account''s email address for account related information.';
 
 
 --
--- Name: COLUMN account.email_address_verification; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.email_address_verification; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.email_address_verification IS 'The UUID used to verify an email address, or null if already verified.';
 
 
 --
--- Name: COLUMN account.email_address_verification_valid_until; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.email_address_verification_valid_until; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.email_address_verification_valid_until IS 'The timestamp until which an email address verification is valid.';
 
 
 --
--- Name: COLUMN account.password_hash; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.password_hash; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.password_hash IS 'The account''s password, hashed and salted.';
 
 
 --
--- Name: COLUMN account.password_reset_verification; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.password_reset_verification; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.password_reset_verification IS 'The UUID used to reset a password, or null if there is no pending reset request.';
 
 
 --
--- Name: COLUMN account.password_reset_verification_valid_until; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.password_reset_verification_valid_until; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.password_reset_verification_valid_until IS 'The timestamp until which a password reset is valid.';
 
 
 --
--- Name: COLUMN account.upload_quota_bytes; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.upload_quota_bytes; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.upload_quota_bytes IS 'The account''s upload quota in bytes.';
 
 
 --
--- Name: COLUMN account.created; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.created; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.created IS 'Timestamp at which the account was last active.';
 
 
 --
--- Name: COLUMN account.last_activity; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN account.last_activity; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.account.last_activity IS 'Timestamp at which the account last requested an access token.';
 
 
 --
--- Name: achievement_code; Type: TABLE; Schema: maevsi_private; Owner: postgres
+-- Name: achievement_code; Type: TABLE; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TABLE maevsi_private.achievement_code (
@@ -3388,38 +3414,38 @@ CREATE TABLE maevsi_private.achievement_code (
 );
 
 
-ALTER TABLE maevsi_private.achievement_code OWNER TO postgres;
+ALTER TABLE maevsi_private.achievement_code OWNER TO ci;
 
 --
--- Name: TABLE achievement_code; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: TABLE achievement_code; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON TABLE maevsi_private.achievement_code IS 'Codes that unlock achievements.';
 
 
 --
--- Name: COLUMN achievement_code.id; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN achievement_code.id; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.achievement_code.id IS 'The code that unlocks an achievement.';
 
 
 --
--- Name: COLUMN achievement_code.alias; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN achievement_code.alias; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.achievement_code.alias IS 'An alternative code, e.g. human readable, that unlocks an achievement.';
 
 
 --
--- Name: COLUMN achievement_code.achievement; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN achievement_code.achievement; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.achievement_code.achievement IS 'The achievement that is unlocked by the code.';
 
 
 --
--- Name: jwt; Type: TABLE; Schema: maevsi_private; Owner: postgres
+-- Name: jwt; Type: TABLE; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TABLE maevsi_private.jwt (
@@ -3428,31 +3454,31 @@ CREATE TABLE maevsi_private.jwt (
 );
 
 
-ALTER TABLE maevsi_private.jwt OWNER TO postgres;
+ALTER TABLE maevsi_private.jwt OWNER TO ci;
 
 --
--- Name: TABLE jwt; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: TABLE jwt; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON TABLE maevsi_private.jwt IS 'A list of tokens.';
 
 
 --
--- Name: COLUMN jwt.id; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN jwt.id; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.jwt.id IS 'The token''s id.';
 
 
 --
--- Name: COLUMN jwt.token; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN jwt.token; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.jwt.token IS 'The token.';
 
 
 --
--- Name: notification; Type: TABLE; Schema: maevsi_private; Owner: postgres
+-- Name: notification; Type: TABLE; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TABLE maevsi_private.notification (
@@ -3465,52 +3491,52 @@ CREATE TABLE maevsi_private.notification (
 );
 
 
-ALTER TABLE maevsi_private.notification OWNER TO postgres;
+ALTER TABLE maevsi_private.notification OWNER TO ci;
 
 --
--- Name: TABLE notification; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: TABLE notification; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON TABLE maevsi_private.notification IS 'A notification.';
 
 
 --
--- Name: COLUMN notification.id; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN notification.id; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.notification.id IS 'The notification''s internal id.';
 
 
 --
--- Name: COLUMN notification.channel; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN notification.channel; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.notification.channel IS 'The notification''s channel.';
 
 
 --
--- Name: COLUMN notification.is_acknowledged; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN notification.is_acknowledged; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.notification.is_acknowledged IS 'Whether the notification was acknowledged.';
 
 
 --
--- Name: COLUMN notification.payload; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN notification.payload; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.notification.payload IS 'The notification''s payload.';
 
 
 --
--- Name: COLUMN notification."timestamp"; Type: COMMENT; Schema: maevsi_private; Owner: postgres
+-- Name: COLUMN notification."timestamp"; Type: COMMENT; Schema: maevsi_private; Owner: ci
 --
 
 COMMENT ON COLUMN maevsi_private.notification."timestamp" IS 'The notification''s timestamp.';
 
 
 --
--- Name: changes; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: changes; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.changes (
@@ -3528,94 +3554,94 @@ CREATE TABLE sqitch.changes (
 );
 
 
-ALTER TABLE sqitch.changes OWNER TO postgres;
+ALTER TABLE sqitch.changes OWNER TO ci;
 
 --
--- Name: TABLE changes; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE changes; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.changes IS 'Tracks the changes currently deployed to the database.';
 
 
 --
--- Name: COLUMN changes.change_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.change_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.change_id IS 'Change primary key.';
 
 
 --
--- Name: COLUMN changes.script_hash; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.script_hash; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.script_hash IS 'Deploy script SHA-1 hash.';
 
 
 --
--- Name: COLUMN changes.change; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.change; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.change IS 'Name of a deployed change.';
 
 
 --
--- Name: COLUMN changes.project; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.project; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.project IS 'Name of the Sqitch project to which the change belongs.';
 
 
 --
--- Name: COLUMN changes.note; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.note; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.note IS 'Description of the change.';
 
 
 --
--- Name: COLUMN changes.committed_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.committed_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.committed_at IS 'Date the change was deployed.';
 
 
 --
--- Name: COLUMN changes.committer_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.committer_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.committer_name IS 'Name of the user who deployed the change.';
 
 
 --
--- Name: COLUMN changes.committer_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.committer_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.committer_email IS 'Email address of the user who deployed the change.';
 
 
 --
--- Name: COLUMN changes.planned_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.planned_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.planned_at IS 'Date the change was added to the plan.';
 
 
 --
--- Name: COLUMN changes.planner_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.planner_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.planner_name IS 'Name of the user who planed the change.';
 
 
 --
--- Name: COLUMN changes.planner_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN changes.planner_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.changes.planner_email IS 'Email address of the user who planned the change.';
 
 
 --
--- Name: dependencies; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: dependencies; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.dependencies (
@@ -3627,45 +3653,45 @@ CREATE TABLE sqitch.dependencies (
 );
 
 
-ALTER TABLE sqitch.dependencies OWNER TO postgres;
+ALTER TABLE sqitch.dependencies OWNER TO ci;
 
 --
--- Name: TABLE dependencies; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE dependencies; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.dependencies IS 'Tracks the currently satisfied dependencies.';
 
 
 --
--- Name: COLUMN dependencies.change_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN dependencies.change_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.dependencies.change_id IS 'ID of the depending change.';
 
 
 --
--- Name: COLUMN dependencies.type; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN dependencies.type; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.dependencies.type IS 'Type of dependency.';
 
 
 --
--- Name: COLUMN dependencies.dependency; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN dependencies.dependency; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.dependencies.dependency IS 'Dependency name.';
 
 
 --
--- Name: COLUMN dependencies.dependency_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN dependencies.dependency_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.dependencies.dependency_id IS 'Change ID the dependency resolves to.';
 
 
 --
--- Name: events; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: events; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.events (
@@ -3687,115 +3713,115 @@ CREATE TABLE sqitch.events (
 );
 
 
-ALTER TABLE sqitch.events OWNER TO postgres;
+ALTER TABLE sqitch.events OWNER TO ci;
 
 --
--- Name: TABLE events; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE events; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.events IS 'Contains full history of all deployment events.';
 
 
 --
--- Name: COLUMN events.event; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.event; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.event IS 'Type of event.';
 
 
 --
--- Name: COLUMN events.change_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.change_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.change_id IS 'Change ID.';
 
 
 --
--- Name: COLUMN events.change; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.change; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.change IS 'Change name.';
 
 
 --
--- Name: COLUMN events.project; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.project; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.project IS 'Name of the Sqitch project to which the change belongs.';
 
 
 --
--- Name: COLUMN events.note; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.note; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.note IS 'Description of the change.';
 
 
 --
--- Name: COLUMN events.requires; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.requires; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.requires IS 'Array of the names of required changes.';
 
 
 --
--- Name: COLUMN events.conflicts; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.conflicts; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.conflicts IS 'Array of the names of conflicting changes.';
 
 
 --
--- Name: COLUMN events.tags; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.tags; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.tags IS 'Tags associated with the change.';
 
 
 --
--- Name: COLUMN events.committed_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.committed_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.committed_at IS 'Date the event was committed.';
 
 
 --
--- Name: COLUMN events.committer_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.committer_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.committer_name IS 'Name of the user who committed the event.';
 
 
 --
--- Name: COLUMN events.committer_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.committer_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.committer_email IS 'Email address of the user who committed the event.';
 
 
 --
--- Name: COLUMN events.planned_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.planned_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.planned_at IS 'Date the event was added to the plan.';
 
 
 --
--- Name: COLUMN events.planner_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.planner_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.planner_name IS 'Name of the user who planed the change.';
 
 
 --
--- Name: COLUMN events.planner_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN events.planner_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.events.planner_email IS 'Email address of the user who plan planned the change.';
 
 
 --
--- Name: projects; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: projects; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.projects (
@@ -3807,52 +3833,52 @@ CREATE TABLE sqitch.projects (
 );
 
 
-ALTER TABLE sqitch.projects OWNER TO postgres;
+ALTER TABLE sqitch.projects OWNER TO ci;
 
 --
--- Name: TABLE projects; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE projects; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.projects IS 'Sqitch projects deployed to this database.';
 
 
 --
--- Name: COLUMN projects.project; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN projects.project; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.projects.project IS 'Unique Name of a project.';
 
 
 --
--- Name: COLUMN projects.uri; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN projects.uri; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.projects.uri IS 'Optional project URI';
 
 
 --
--- Name: COLUMN projects.created_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN projects.created_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.projects.created_at IS 'Date the project was added to the database.';
 
 
 --
--- Name: COLUMN projects.creator_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN projects.creator_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.projects.creator_name IS 'Name of the user who added the project.';
 
 
 --
--- Name: COLUMN projects.creator_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN projects.creator_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.projects.creator_email IS 'Email address of the user who added the project.';
 
 
 --
--- Name: releases; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: releases; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.releases (
@@ -3863,45 +3889,45 @@ CREATE TABLE sqitch.releases (
 );
 
 
-ALTER TABLE sqitch.releases OWNER TO postgres;
+ALTER TABLE sqitch.releases OWNER TO ci;
 
 --
--- Name: TABLE releases; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE releases; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.releases IS 'Sqitch registry releases.';
 
 
 --
--- Name: COLUMN releases.version; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN releases.version; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.releases.version IS 'Version of the Sqitch registry.';
 
 
 --
--- Name: COLUMN releases.installed_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN releases.installed_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.releases.installed_at IS 'Date the registry release was installed.';
 
 
 --
--- Name: COLUMN releases.installer_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN releases.installer_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.releases.installer_name IS 'Name of the user who installed the registry release.';
 
 
 --
--- Name: COLUMN releases.installer_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN releases.installer_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.releases.installer_email IS 'Email address of the user who installed the registry release.';
 
 
 --
--- Name: tags; Type: TABLE; Schema: sqitch; Owner: postgres
+-- Name: tags; Type: TABLE; Schema: sqitch; Owner: ci
 --
 
 CREATE TABLE sqitch.tags (
@@ -3919,94 +3945,94 @@ CREATE TABLE sqitch.tags (
 );
 
 
-ALTER TABLE sqitch.tags OWNER TO postgres;
+ALTER TABLE sqitch.tags OWNER TO ci;
 
 --
--- Name: TABLE tags; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: TABLE tags; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON TABLE sqitch.tags IS 'Tracks the tags currently applied to the database.';
 
 
 --
--- Name: COLUMN tags.tag_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.tag_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.tag_id IS 'Tag primary key.';
 
 
 --
--- Name: COLUMN tags.tag; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.tag; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.tag IS 'Project-unique tag name.';
 
 
 --
--- Name: COLUMN tags.project; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.project; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.project IS 'Name of the Sqitch project to which the tag belongs.';
 
 
 --
--- Name: COLUMN tags.change_id; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.change_id; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.change_id IS 'ID of last change deployed before the tag was applied.';
 
 
 --
--- Name: COLUMN tags.note; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.note; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.note IS 'Description of the tag.';
 
 
 --
--- Name: COLUMN tags.committed_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.committed_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.committed_at IS 'Date the tag was applied to the database.';
 
 
 --
--- Name: COLUMN tags.committer_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.committer_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.committer_name IS 'Name of the user who applied the tag.';
 
 
 --
--- Name: COLUMN tags.committer_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.committer_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.committer_email IS 'Email address of the user who applied the tag.';
 
 
 --
--- Name: COLUMN tags.planned_at; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.planned_at; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.planned_at IS 'Date the tag was added to the plan.';
 
 
 --
--- Name: COLUMN tags.planner_name; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.planner_name; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.planner_name IS 'Name of the user who planed the tag.';
 
 
 --
--- Name: COLUMN tags.planner_email; Type: COMMENT; Schema: sqitch; Owner: postgres
+-- Name: COLUMN tags.planner_email; Type: COMMENT; Schema: sqitch; Owner: ci
 --
 
 COMMENT ON COLUMN sqitch.tags.planner_email IS 'Email address of the user who planned the tag.';
 
 
 --
--- Name: account_block account_block_author_account_id_blocked_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_author_account_id_blocked_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_block
@@ -4014,7 +4040,7 @@ ALTER TABLE ONLY maevsi.account_block
 
 
 --
--- Name: account_block account_block_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_block
@@ -4022,7 +4048,7 @@ ALTER TABLE ONLY maevsi.account_block
 
 
 --
--- Name: account_interest account_interest_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_interest
@@ -4030,7 +4056,7 @@ ALTER TABLE ONLY maevsi.account_interest
 
 
 --
--- Name: account account_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account account_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account
@@ -4038,7 +4064,7 @@ ALTER TABLE ONLY maevsi.account
 
 
 --
--- Name: account_preference_event_size account_preference_event_size_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size account_preference_event_size_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_preference_event_size
@@ -4046,7 +4072,7 @@ ALTER TABLE ONLY maevsi.account_preference_event_size
 
 
 --
--- Name: account_social_network account_social_network_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_social_network account_social_network_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_social_network
@@ -4054,14 +4080,14 @@ ALTER TABLE ONLY maevsi.account_social_network
 
 
 --
--- Name: CONSTRAINT account_social_network_pkey ON account_social_network; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: CONSTRAINT account_social_network_pkey ON account_social_network; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON CONSTRAINT account_social_network_pkey ON maevsi.account_social_network IS 'Ensures uniqueness by combining the account ID and social network, allowing each account to have a single entry per social network.';
 
 
 --
--- Name: account account_username_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account account_username_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account
@@ -4069,7 +4095,7 @@ ALTER TABLE ONLY maevsi.account
 
 
 --
--- Name: achievement achievement_account_id_achievement_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: achievement achievement_account_id_achievement_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.achievement
@@ -4077,7 +4103,7 @@ ALTER TABLE ONLY maevsi.achievement
 
 
 --
--- Name: achievement achievement_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: achievement achievement_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.achievement
@@ -4085,7 +4111,7 @@ ALTER TABLE ONLY maevsi.achievement
 
 
 --
--- Name: contact contact_author_account_id_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: contact contact_author_account_id_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.contact
@@ -4093,7 +4119,7 @@ ALTER TABLE ONLY maevsi.contact
 
 
 --
--- Name: contact contact_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: contact contact_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.contact
@@ -4101,7 +4127,7 @@ ALTER TABLE ONLY maevsi.contact
 
 
 --
--- Name: event event_author_account_id_slug_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event event_author_account_id_slug_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event
@@ -4109,7 +4135,7 @@ ALTER TABLE ONLY maevsi.event
 
 
 --
--- Name: event_category_mapping event_category_mapping_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_category_mapping
@@ -4117,7 +4143,7 @@ ALTER TABLE ONLY maevsi.event_category_mapping
 
 
 --
--- Name: event_category event_category_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_category event_category_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_category
@@ -4125,7 +4151,7 @@ ALTER TABLE ONLY maevsi.event_category
 
 
 --
--- Name: event_favourite event_favourite_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_favourite event_favourite_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_favourite
@@ -4133,7 +4159,7 @@ ALTER TABLE ONLY maevsi.event_favourite
 
 
 --
--- Name: event_group event_group_author_account_id_slug_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_group event_group_author_account_id_slug_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_group
@@ -4141,7 +4167,7 @@ ALTER TABLE ONLY maevsi.event_group
 
 
 --
--- Name: event_group event_group_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_group event_group_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_group
@@ -4149,7 +4175,7 @@ ALTER TABLE ONLY maevsi.event_group
 
 
 --
--- Name: event_grouping event_grouping_event_id_event_group_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_grouping event_grouping_event_id_event_group_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_grouping
@@ -4157,7 +4183,7 @@ ALTER TABLE ONLY maevsi.event_grouping
 
 
 --
--- Name: event_grouping event_grouping_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_grouping event_grouping_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_grouping
@@ -4165,7 +4191,7 @@ ALTER TABLE ONLY maevsi.event_grouping
 
 
 --
--- Name: event event_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event event_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event
@@ -4173,7 +4199,7 @@ ALTER TABLE ONLY maevsi.event
 
 
 --
--- Name: event_recommendation event_recommendation_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation event_recommendation_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_recommendation
@@ -4181,7 +4207,7 @@ ALTER TABLE ONLY maevsi.event_recommendation
 
 
 --
--- Name: event_upload event_upload_event_id_upload_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_event_id_upload_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_upload
@@ -4189,7 +4215,7 @@ ALTER TABLE ONLY maevsi.event_upload
 
 
 --
--- Name: event_upload event_upload_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_upload
@@ -4197,7 +4223,7 @@ ALTER TABLE ONLY maevsi.event_upload
 
 
 --
--- Name: invitation invitation_event_id_contact_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_event_id_contact_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.invitation
@@ -4205,7 +4231,7 @@ ALTER TABLE ONLY maevsi.invitation
 
 
 --
--- Name: invitation invitation_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.invitation
@@ -4213,7 +4239,7 @@ ALTER TABLE ONLY maevsi.invitation
 
 
 --
--- Name: legal_term_acceptance legal_term_acceptance_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance legal_term_acceptance_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.legal_term_acceptance
@@ -4221,7 +4247,7 @@ ALTER TABLE ONLY maevsi.legal_term_acceptance
 
 
 --
--- Name: legal_term legal_term_language_version_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: legal_term legal_term_language_version_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.legal_term
@@ -4229,7 +4255,7 @@ ALTER TABLE ONLY maevsi.legal_term
 
 
 --
--- Name: legal_term legal_term_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: legal_term legal_term_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.legal_term
@@ -4237,7 +4263,7 @@ ALTER TABLE ONLY maevsi.legal_term
 
 
 --
--- Name: profile_picture profile_picture_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_account_id_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.profile_picture
@@ -4245,7 +4271,7 @@ ALTER TABLE ONLY maevsi.profile_picture
 
 
 --
--- Name: profile_picture profile_picture_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.profile_picture
@@ -4253,7 +4279,7 @@ ALTER TABLE ONLY maevsi.profile_picture
 
 
 --
--- Name: report report_author_account_id_target_account_id_target_event_id__key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_author_account_id_target_account_id_target_event_id__key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4261,14 +4287,14 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: CONSTRAINT report_author_account_id_target_account_id_target_event_id__key ON report; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: CONSTRAINT report_author_account_id_target_account_id_target_event_id__key ON report; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON CONSTRAINT report_author_account_id_target_account_id_target_event_id__key ON maevsi.report IS 'Ensures that the same user cannot submit multiple reports on the same element (account, event, or upload).';
 
 
 --
--- Name: report report_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4276,7 +4302,7 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: upload upload_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: upload upload_pkey; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.upload
@@ -4284,7 +4310,7 @@ ALTER TABLE ONLY maevsi.upload
 
 
 --
--- Name: upload upload_storage_key_key; Type: CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: upload upload_storage_key_key; Type: CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.upload
@@ -4292,7 +4318,7 @@ ALTER TABLE ONLY maevsi.upload
 
 
 --
--- Name: account account_email_address_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: account account_email_address_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.account
@@ -4300,7 +4326,7 @@ ALTER TABLE ONLY maevsi_private.account
 
 
 --
--- Name: account account_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: account account_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.account
@@ -4308,7 +4334,7 @@ ALTER TABLE ONLY maevsi_private.account
 
 
 --
--- Name: achievement_code achievement_code_alias_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: achievement_code achievement_code_alias_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.achievement_code
@@ -4316,7 +4342,7 @@ ALTER TABLE ONLY maevsi_private.achievement_code
 
 
 --
--- Name: achievement_code achievement_code_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: achievement_code achievement_code_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.achievement_code
@@ -4324,7 +4350,7 @@ ALTER TABLE ONLY maevsi_private.achievement_code
 
 
 --
--- Name: jwt jwt_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: jwt jwt_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.jwt
@@ -4332,7 +4358,7 @@ ALTER TABLE ONLY maevsi_private.jwt
 
 
 --
--- Name: jwt jwt_token_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: jwt jwt_token_key; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.jwt
@@ -4340,7 +4366,7 @@ ALTER TABLE ONLY maevsi_private.jwt
 
 
 --
--- Name: notification notification_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: postgres
+-- Name: notification notification_pkey; Type: CONSTRAINT; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi_private.notification
@@ -4348,7 +4374,7 @@ ALTER TABLE ONLY maevsi_private.notification
 
 
 --
--- Name: changes changes_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: changes changes_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.changes
@@ -4356,7 +4382,7 @@ ALTER TABLE ONLY sqitch.changes
 
 
 --
--- Name: changes changes_project_script_hash_key; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: changes changes_project_script_hash_key; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.changes
@@ -4364,7 +4390,7 @@ ALTER TABLE ONLY sqitch.changes
 
 
 --
--- Name: dependencies dependencies_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: dependencies dependencies_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.dependencies
@@ -4372,7 +4398,7 @@ ALTER TABLE ONLY sqitch.dependencies
 
 
 --
--- Name: events events_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.events
@@ -4380,7 +4406,7 @@ ALTER TABLE ONLY sqitch.events
 
 
 --
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.projects
@@ -4388,7 +4414,7 @@ ALTER TABLE ONLY sqitch.projects
 
 
 --
--- Name: projects projects_uri_key; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: projects projects_uri_key; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.projects
@@ -4396,7 +4422,7 @@ ALTER TABLE ONLY sqitch.projects
 
 
 --
--- Name: releases releases_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: releases releases_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.releases
@@ -4404,7 +4430,7 @@ ALTER TABLE ONLY sqitch.releases
 
 
 --
--- Name: tags tags_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: tags tags_pkey; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.tags
@@ -4412,7 +4438,7 @@ ALTER TABLE ONLY sqitch.tags
 
 
 --
--- Name: tags tags_project_tag_key; Type: CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: tags tags_project_tag_key; Type: CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.tags
@@ -4420,133 +4446,133 @@ ALTER TABLE ONLY sqitch.tags
 
 
 --
--- Name: idx_event_author_account_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_event_author_account_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_event_author_account_id ON maevsi.event USING btree (author_account_id);
 
 
 --
--- Name: INDEX idx_event_author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_event_author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_event_author_account_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: idx_event_group_author_account_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_event_group_author_account_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_event_group_author_account_id ON maevsi.event_group USING btree (author_account_id);
 
 
 --
--- Name: INDEX idx_event_group_author_account_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_event_group_author_account_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_event_group_author_account_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: idx_event_grouping_event_group_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_event_grouping_event_group_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_event_grouping_event_group_id ON maevsi.event_grouping USING btree (event_group_id);
 
 
 --
--- Name: INDEX idx_event_grouping_event_group_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_event_grouping_event_group_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_event_grouping_event_group_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: idx_event_grouping_event_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_event_grouping_event_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_event_grouping_event_id ON maevsi.event_grouping USING btree (event_id);
 
 
 --
--- Name: INDEX idx_event_grouping_event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_event_grouping_event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_event_grouping_event_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: idx_invitation_contact_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_invitation_contact_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_invitation_contact_id ON maevsi.invitation USING btree (contact_id);
 
 
 --
--- Name: INDEX idx_invitation_contact_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_invitation_contact_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_invitation_contact_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: idx_invitation_event_id; Type: INDEX; Schema: maevsi; Owner: postgres
+-- Name: idx_invitation_event_id; Type: INDEX; Schema: maevsi; Owner: ci
 --
 
 CREATE INDEX idx_invitation_event_id ON maevsi.invitation USING btree (event_id);
 
 
 --
--- Name: INDEX idx_invitation_event_id; Type: COMMENT; Schema: maevsi; Owner: postgres
+-- Name: INDEX idx_invitation_event_id; Type: COMMENT; Schema: maevsi; Owner: ci
 --
 
 COMMENT ON INDEX maevsi.idx_invitation_event_id IS 'Speeds up reverse foreign key lookups.';
 
 
 --
--- Name: invitation maevsi_invitation_update; Type: TRIGGER; Schema: maevsi; Owner: postgres
+-- Name: invitation maevsi_invitation_update; Type: TRIGGER; Schema: maevsi; Owner: ci
 --
 
 CREATE TRIGGER maevsi_invitation_update BEFORE UPDATE ON maevsi.invitation FOR EACH ROW EXECUTE FUNCTION maevsi.trigger_invitation_update();
 
 
 --
--- Name: legal_term maevsi_legal_term_delete; Type: TRIGGER; Schema: maevsi; Owner: postgres
+-- Name: legal_term maevsi_legal_term_delete; Type: TRIGGER; Schema: maevsi; Owner: ci
 --
 
 CREATE TRIGGER maevsi_legal_term_delete BEFORE DELETE ON maevsi.legal_term FOR EACH ROW EXECUTE FUNCTION maevsi.legal_term_change();
 
 
 --
--- Name: legal_term maevsi_legal_term_update; Type: TRIGGER; Schema: maevsi; Owner: postgres
+-- Name: legal_term maevsi_legal_term_update; Type: TRIGGER; Schema: maevsi; Owner: ci
 --
 
 CREATE TRIGGER maevsi_legal_term_update BEFORE UPDATE ON maevsi.legal_term FOR EACH ROW EXECUTE FUNCTION maevsi.legal_term_change();
 
 
 --
--- Name: contact maevsi_trigger_contact_update_account_id; Type: TRIGGER; Schema: maevsi; Owner: postgres
+-- Name: contact maevsi_trigger_contact_update_account_id; Type: TRIGGER; Schema: maevsi; Owner: ci
 --
 
 CREATE TRIGGER maevsi_trigger_contact_update_account_id BEFORE UPDATE OF account_id, author_account_id ON maevsi.contact FOR EACH ROW EXECUTE FUNCTION maevsi.trigger_contact_update_account_id();
 
 
 --
--- Name: account maevsi_private_account_email_address_verification_valid_until; Type: TRIGGER; Schema: maevsi_private; Owner: postgres
+-- Name: account maevsi_private_account_email_address_verification_valid_until; Type: TRIGGER; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TRIGGER maevsi_private_account_email_address_verification_valid_until BEFORE INSERT OR UPDATE OF email_address_verification ON maevsi_private.account FOR EACH ROW EXECUTE FUNCTION maevsi_private.account_email_address_verification_valid_until();
 
 
 --
--- Name: account maevsi_private_account_password_reset_verification_valid_until; Type: TRIGGER; Schema: maevsi_private; Owner: postgres
+-- Name: account maevsi_private_account_password_reset_verification_valid_until; Type: TRIGGER; Schema: maevsi_private; Owner: ci
 --
 
 CREATE TRIGGER maevsi_private_account_password_reset_verification_valid_until BEFORE INSERT OR UPDATE OF password_reset_verification ON maevsi_private.account FOR EACH ROW EXECUTE FUNCTION maevsi_private.account_password_reset_verification_valid_until();
 
 
 --
--- Name: account_block account_block_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_block
@@ -4554,7 +4580,7 @@ ALTER TABLE ONLY maevsi.account_block
 
 
 --
--- Name: account_block account_block_blocked_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_blocked_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_block
@@ -4562,7 +4588,7 @@ ALTER TABLE ONLY maevsi.account_block
 
 
 --
--- Name: account account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account
@@ -4570,7 +4596,7 @@ ALTER TABLE ONLY maevsi.account
 
 
 --
--- Name: account_interest account_interest_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_interest
@@ -4578,7 +4604,7 @@ ALTER TABLE ONLY maevsi.account_interest
 
 
 --
--- Name: account_interest account_interest_category_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_category_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_interest
@@ -4586,7 +4612,7 @@ ALTER TABLE ONLY maevsi.account_interest
 
 
 --
--- Name: account_preference_event_size account_preference_event_size_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size account_preference_event_size_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_preference_event_size
@@ -4594,7 +4620,7 @@ ALTER TABLE ONLY maevsi.account_preference_event_size
 
 
 --
--- Name: account_social_network account_social_network_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: account_social_network account_social_network_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.account_social_network
@@ -4602,7 +4628,7 @@ ALTER TABLE ONLY maevsi.account_social_network
 
 
 --
--- Name: achievement achievement_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: achievement achievement_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.achievement
@@ -4610,7 +4636,7 @@ ALTER TABLE ONLY maevsi.achievement
 
 
 --
--- Name: contact contact_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: contact contact_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.contact
@@ -4618,7 +4644,7 @@ ALTER TABLE ONLY maevsi.contact
 
 
 --
--- Name: contact contact_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: contact contact_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.contact
@@ -4626,7 +4652,7 @@ ALTER TABLE ONLY maevsi.contact
 
 
 --
--- Name: event event_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event event_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event
@@ -4634,7 +4660,7 @@ ALTER TABLE ONLY maevsi.event
 
 
 --
--- Name: event_category_mapping event_category_mapping_category_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_category_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_category_mapping
@@ -4642,7 +4668,7 @@ ALTER TABLE ONLY maevsi.event_category_mapping
 
 
 --
--- Name: event_category_mapping event_category_mapping_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_category_mapping
@@ -4650,7 +4676,7 @@ ALTER TABLE ONLY maevsi.event_category_mapping
 
 
 --
--- Name: event_favourite event_favourite_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_favourite event_favourite_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_favourite
@@ -4658,7 +4684,7 @@ ALTER TABLE ONLY maevsi.event_favourite
 
 
 --
--- Name: event_favourite event_favourite_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_favourite event_favourite_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_favourite
@@ -4666,7 +4692,7 @@ ALTER TABLE ONLY maevsi.event_favourite
 
 
 --
--- Name: event_group event_group_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_group event_group_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_group
@@ -4674,7 +4700,7 @@ ALTER TABLE ONLY maevsi.event_group
 
 
 --
--- Name: event_grouping event_grouping_event_group_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_grouping event_grouping_event_group_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_grouping
@@ -4682,7 +4708,7 @@ ALTER TABLE ONLY maevsi.event_grouping
 
 
 --
--- Name: event_grouping event_grouping_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_grouping event_grouping_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_grouping
@@ -4690,7 +4716,7 @@ ALTER TABLE ONLY maevsi.event_grouping
 
 
 --
--- Name: event_recommendation event_recommendation_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation event_recommendation_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_recommendation
@@ -4698,7 +4724,7 @@ ALTER TABLE ONLY maevsi.event_recommendation
 
 
 --
--- Name: event_recommendation event_recommendation_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation event_recommendation_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_recommendation
@@ -4706,7 +4732,7 @@ ALTER TABLE ONLY maevsi.event_recommendation
 
 
 --
--- Name: event_upload event_upload_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_upload
@@ -4714,7 +4740,7 @@ ALTER TABLE ONLY maevsi.event_upload
 
 
 --
--- Name: event_upload event_upload_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.event_upload
@@ -4722,7 +4748,7 @@ ALTER TABLE ONLY maevsi.event_upload
 
 
 --
--- Name: invitation invitation_contact_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_contact_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.invitation
@@ -4730,7 +4756,7 @@ ALTER TABLE ONLY maevsi.invitation
 
 
 --
--- Name: invitation invitation_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.invitation
@@ -4738,7 +4764,7 @@ ALTER TABLE ONLY maevsi.invitation
 
 
 --
--- Name: invitation invitation_updated_by_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_updated_by_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.invitation
@@ -4746,7 +4772,7 @@ ALTER TABLE ONLY maevsi.invitation
 
 
 --
--- Name: legal_term_acceptance legal_term_acceptance_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance legal_term_acceptance_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.legal_term_acceptance
@@ -4754,7 +4780,7 @@ ALTER TABLE ONLY maevsi.legal_term_acceptance
 
 
 --
--- Name: legal_term_acceptance legal_term_acceptance_legal_term_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance legal_term_acceptance_legal_term_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.legal_term_acceptance
@@ -4762,7 +4788,7 @@ ALTER TABLE ONLY maevsi.legal_term_acceptance
 
 
 --
--- Name: profile_picture profile_picture_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.profile_picture
@@ -4770,7 +4796,7 @@ ALTER TABLE ONLY maevsi.profile_picture
 
 
 --
--- Name: profile_picture profile_picture_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.profile_picture
@@ -4778,7 +4804,7 @@ ALTER TABLE ONLY maevsi.profile_picture
 
 
 --
--- Name: report report_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_author_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4786,7 +4812,7 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: report report_target_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_target_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4794,7 +4820,7 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: report report_target_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_target_event_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4802,7 +4828,7 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: report report_target_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: report report_target_upload_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.report
@@ -4810,7 +4836,7 @@ ALTER TABLE ONLY maevsi.report
 
 
 --
--- Name: upload upload_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: postgres
+-- Name: upload upload_account_id_fkey; Type: FK CONSTRAINT; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE ONLY maevsi.upload
@@ -4818,7 +4844,7 @@ ALTER TABLE ONLY maevsi.upload
 
 
 --
--- Name: changes changes_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: changes changes_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.changes
@@ -4826,7 +4852,7 @@ ALTER TABLE ONLY sqitch.changes
 
 
 --
--- Name: dependencies dependencies_change_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: dependencies dependencies_change_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.dependencies
@@ -4834,7 +4860,7 @@ ALTER TABLE ONLY sqitch.dependencies
 
 
 --
--- Name: dependencies dependencies_dependency_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: dependencies dependencies_dependency_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.dependencies
@@ -4842,7 +4868,7 @@ ALTER TABLE ONLY sqitch.dependencies
 
 
 --
--- Name: events events_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: events events_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.events
@@ -4850,7 +4876,7 @@ ALTER TABLE ONLY sqitch.events
 
 
 --
--- Name: tags tags_change_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: tags tags_change_id_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.tags
@@ -4858,7 +4884,7 @@ ALTER TABLE ONLY sqitch.tags
 
 
 --
--- Name: tags tags_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: postgres
+-- Name: tags tags_project_fkey; Type: FK CONSTRAINT; Schema: sqitch; Owner: ci
 --
 
 ALTER TABLE ONLY sqitch.tags
@@ -4866,147 +4892,147 @@ ALTER TABLE ONLY sqitch.tags
 
 
 --
--- Name: account; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: account; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.account ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: account_block; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: account_block; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.account_block ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: account_block account_block_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_block_insert ON maevsi.account_block FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: account_block account_block_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_block account_block_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_block_select ON maevsi.account_block FOR SELECT USING (((author_account_id = maevsi.invoker_account_id()) OR (blocked_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: account_interest; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: account_interest; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.account_interest ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: account_interest account_interest_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_interest_delete ON maevsi.account_interest FOR DELETE USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_interest account_interest_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_interest_insert ON maevsi.account_interest FOR INSERT WITH CHECK ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_interest account_interest_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_interest account_interest_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_interest_select ON maevsi.account_interest FOR SELECT USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_preference_event_size; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.account_preference_event_size ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: account_preference_event_size account_preference_event_size_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size account_preference_event_size_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_preference_event_size_delete ON maevsi.account_preference_event_size FOR DELETE USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_preference_event_size account_preference_event_size_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size account_preference_event_size_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_preference_event_size_insert ON maevsi.account_preference_event_size FOR INSERT WITH CHECK ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_preference_event_size account_preference_event_size_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_preference_event_size account_preference_event_size_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_preference_event_size_select ON maevsi.account_preference_event_size FOR SELECT USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account account_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account account_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_select ON maevsi.account FOR SELECT USING (true);
 
 
 --
--- Name: account_social_network; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: account_social_network; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.account_social_network ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: account_social_network account_social_network_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_social_network account_social_network_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_social_network_delete ON maevsi.account_social_network FOR DELETE USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_social_network account_social_network_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_social_network account_social_network_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_social_network_insert ON maevsi.account_social_network FOR INSERT WITH CHECK ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: account_social_network account_social_network_update; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: account_social_network account_social_network_update; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY account_social_network_update ON maevsi.account_social_network FOR UPDATE USING ((account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: achievement; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: achievement; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.achievement ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: achievement achievement_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: achievement achievement_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY achievement_select ON maevsi.achievement FOR SELECT USING (true);
 
 
 --
--- Name: contact; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: contact; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.contact ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: contact contact_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: contact contact_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY contact_delete ON maevsi.contact FOR DELETE USING (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id()) AND (account_id IS DISTINCT FROM maevsi.invoker_account_id())));
 
 
 --
--- Name: contact contact_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: contact contact_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY contact_insert ON maevsi.contact FOR INSERT WITH CHECK (((author_account_id = maevsi.invoker_account_id()) AND (NOT (account_id IN ( SELECT account_block.blocked_account_id
@@ -5015,7 +5041,7 @@ CREATE POLICY contact_insert ON maevsi.contact FOR INSERT WITH CHECK (((author_a
 
 
 --
--- Name: contact contact_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: contact contact_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY contact_select ON maevsi.contact FOR SELECT USING ((((account_id = maevsi.invoker_account_id()) AND (NOT (author_account_id IN ( SELECT account_block_ids.id
@@ -5024,7 +5050,7 @@ CREATE POLICY contact_select ON maevsi.contact FOR SELECT USING ((((account_id =
 
 
 --
--- Name: contact contact_update; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: contact contact_update; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY contact_update ON maevsi.contact FOR UPDATE USING (((author_account_id = maevsi.invoker_account_id()) AND (NOT (account_id IN ( SELECT account_block.blocked_account_id
@@ -5033,19 +5059,19 @@ CREATE POLICY contact_update ON maevsi.contact FOR UPDATE USING (((author_accoun
 
 
 --
--- Name: event; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_category_mapping; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_category_mapping ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_category_mapping event_category_mapping_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_category_mapping_delete ON maevsi.event_category_mapping FOR DELETE USING (((maevsi.invoker_account_id() IS NOT NULL) AND (( SELECT event.author_account_id
@@ -5054,7 +5080,7 @@ CREATE POLICY event_category_mapping_delete ON maevsi.event_category_mapping FOR
 
 
 --
--- Name: event_category_mapping event_category_mapping_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_category_mapping_insert ON maevsi.event_category_mapping FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (( SELECT event.author_account_id
@@ -5063,7 +5089,7 @@ CREATE POLICY event_category_mapping_insert ON maevsi.event_category_mapping FOR
 
 
 --
--- Name: event_category_mapping event_category_mapping_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_category_mapping event_category_mapping_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_category_mapping_select ON maevsi.event_category_mapping FOR SELECT USING ((((maevsi.invoker_account_id() IS NOT NULL) AND (( SELECT event.author_account_id
@@ -5077,59 +5103,59 @@ CREATE POLICY event_category_mapping_select ON maevsi.event_category_mapping FOR
 
 
 --
--- Name: event event_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event event_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_delete ON maevsi.event FOR DELETE USING ((author_account_id = maevsi.invoker_account_id()));
 
 
 --
--- Name: event_favourite; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_favourite; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_favourite ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_favourite event_favourite_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_favourite event_favourite_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_favourite_select ON maevsi.event_favourite FOR SELECT USING (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: event_group; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_group; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_group ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_grouping; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_grouping; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_grouping ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event event_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event event_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_insert ON maevsi.event FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: event_recommendation; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_recommendation ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_recommendation event_recommendation_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_recommendation event_recommendation_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_recommendation_select ON maevsi.event_recommendation FOR SELECT USING (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: event event_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event event_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_select ON maevsi.event FOR SELECT USING ((((visibility = 'public'::maevsi.event_visibility) AND ((invitee_count_maximum IS NULL) OR (invitee_count_maximum > maevsi.invitee_count(id))) AND (NOT (author_account_id IN ( SELECT account_block_ids.id
@@ -5137,20 +5163,20 @@ CREATE POLICY event_select ON maevsi.event FOR SELECT USING ((((visibility = 'pu
 
 
 --
--- Name: event event_update; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event event_update; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_update ON maevsi.event FOR UPDATE USING (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: event_upload; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: event_upload; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.event_upload ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: event_upload event_upload_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_upload_delete ON maevsi.event_upload FOR DELETE USING ((event_id IN ( SELECT event.id
@@ -5159,7 +5185,7 @@ CREATE POLICY event_upload_delete ON maevsi.event_upload FOR DELETE USING ((even
 
 
 --
--- Name: event_upload event_upload_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (((event_id IN ( SELECT event.id
@@ -5170,7 +5196,7 @@ CREATE POLICY event_upload_insert ON maevsi.event_upload FOR INSERT WITH CHECK (
 
 
 --
--- Name: event_upload event_upload_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: event_upload event_upload_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING ((event_id IN ( SELECT event.id
@@ -5178,20 +5204,20 @@ CREATE POLICY event_upload_select ON maevsi.event_upload FOR SELECT USING ((even
 
 
 --
--- Name: invitation; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: invitation; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.invitation ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: invitation invitation_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY invitation_delete ON maevsi.invitation FOR DELETE USING ((event_id IN ( SELECT maevsi.events_organized() AS events_organized)));
 
 
 --
--- Name: invitation invitation_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY invitation_insert ON maevsi.invitation FOR INSERT WITH CHECK (((event_id IN ( SELECT maevsi.events_organized() AS events_organized)) AND ((maevsi.event_invitee_count_maximum(event_id) IS NULL) OR (maevsi.event_invitee_count_maximum(event_id) > maevsi.invitee_count(event_id))) AND (contact_id IN ( SELECT contact.id
@@ -5205,7 +5231,7 @@ EXCEPT
 
 
 --
--- Name: invitation invitation_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY invitation_select ON maevsi.invitation FOR SELECT USING (((id = ANY (maevsi.invitation_claim_array())) OR (contact_id IN ( SELECT contact.id
@@ -5222,7 +5248,7 @@ EXCEPT
 
 
 --
--- Name: invitation invitation_update; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: invitation invitation_update; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY invitation_update ON maevsi.invitation FOR UPDATE USING (((id = ANY (maevsi.invitation_claim_array())) OR (contact_id IN ( SELECT contact.id
@@ -5239,107 +5265,107 @@ EXCEPT
 
 
 --
--- Name: legal_term; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: legal_term; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.legal_term ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: legal_term_acceptance; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.legal_term_acceptance ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: legal_term_acceptance legal_term_acceptance_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance legal_term_acceptance_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY legal_term_acceptance_insert ON maevsi.legal_term_acceptance FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: legal_term_acceptance legal_term_acceptance_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: legal_term_acceptance legal_term_acceptance_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY legal_term_acceptance_select ON maevsi.legal_term_acceptance FOR SELECT USING (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: legal_term legal_term_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: legal_term legal_term_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY legal_term_select ON maevsi.legal_term FOR SELECT USING (true);
 
 
 --
--- Name: profile_picture; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: profile_picture; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.profile_picture ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: profile_picture profile_picture_delete; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_delete; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY profile_picture_delete ON maevsi.profile_picture FOR DELETE USING (((( SELECT CURRENT_USER AS "current_user") = 'maevsi_tusd'::name) OR ((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id()))));
 
 
 --
--- Name: profile_picture profile_picture_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY profile_picture_insert ON maevsi.profile_picture FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: profile_picture profile_picture_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY profile_picture_select ON maevsi.profile_picture FOR SELECT USING (true);
 
 
 --
--- Name: profile_picture profile_picture_update; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: profile_picture profile_picture_update; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY profile_picture_update ON maevsi.profile_picture FOR UPDATE USING (((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: report; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: report; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.report ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: report report_insert; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: report report_insert; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY report_insert ON maevsi.report FOR INSERT WITH CHECK (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: report report_select; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: report report_select; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY report_select ON maevsi.report FOR SELECT USING (((maevsi.invoker_account_id() IS NOT NULL) AND (author_account_id = maevsi.invoker_account_id())));
 
 
 --
--- Name: upload; Type: ROW SECURITY; Schema: maevsi; Owner: postgres
+-- Name: upload; Type: ROW SECURITY; Schema: maevsi; Owner: ci
 --
 
 ALTER TABLE maevsi.upload ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: upload upload_delete_using; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: upload upload_delete_using; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY upload_delete_using ON maevsi.upload FOR DELETE USING ((( SELECT CURRENT_USER AS "current_user") = 'maevsi_tusd'::name));
 
 
 --
--- Name: upload upload_select_using; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: upload upload_select_using; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY upload_select_using ON maevsi.upload FOR SELECT USING (((( SELECT CURRENT_USER AS "current_user") = 'maevsi_tusd'::name) OR ((maevsi.invoker_account_id() IS NOT NULL) AND (account_id = maevsi.invoker_account_id())) OR (id IN ( SELECT profile_picture.upload_id
@@ -5347,27 +5373,27 @@ CREATE POLICY upload_select_using ON maevsi.upload FOR SELECT USING (((( SELECT 
 
 
 --
--- Name: upload upload_update_using; Type: POLICY; Schema: maevsi; Owner: postgres
+-- Name: upload upload_update_using; Type: POLICY; Schema: maevsi; Owner: ci
 --
 
 CREATE POLICY upload_update_using ON maevsi.upload FOR UPDATE USING ((( SELECT CURRENT_USER AS "current_user") = 'maevsi_tusd'::name));
 
 
 --
--- Name: achievement_code; Type: ROW SECURITY; Schema: maevsi_private; Owner: postgres
+-- Name: achievement_code; Type: ROW SECURITY; Schema: maevsi_private; Owner: ci
 --
 
 ALTER TABLE maevsi_private.achievement_code ENABLE ROW LEVEL SECURITY;
 
 --
--- Name: achievement_code achievement_code_select; Type: POLICY; Schema: maevsi_private; Owner: postgres
+-- Name: achievement_code achievement_code_select; Type: POLICY; Schema: maevsi_private; Owner: ci
 --
 
 CREATE POLICY achievement_code_select ON maevsi_private.achievement_code FOR SELECT USING (true);
 
 
 --
--- Name: SCHEMA maevsi; Type: ACL; Schema: -; Owner: postgres
+-- Name: SCHEMA maevsi; Type: ACL; Schema: -; Owner: ci
 --
 
 GRANT USAGE ON SCHEMA maevsi TO maevsi_anonymous;
@@ -5376,7 +5402,15 @@ GRANT USAGE ON SCHEMA maevsi TO maevsi_tusd;
 
 
 --
--- Name: FUNCTION account_delete(password text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: SCHEMA maevsi_test; Type: ACL; Schema: -; Owner: ci
+--
+
+GRANT USAGE ON SCHEMA maevsi_test TO maevsi_anonymous;
+GRANT USAGE ON SCHEMA maevsi_test TO maevsi_account;
+
+
+--
+-- Name: FUNCTION account_delete(password text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_delete(password text) FROM PUBLIC;
@@ -5384,7 +5418,7 @@ GRANT ALL ON FUNCTION maevsi.account_delete(password text) TO maevsi_account;
 
 
 --
--- Name: FUNCTION account_email_address_verification(code uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_email_address_verification(code uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_email_address_verification(code uuid) FROM PUBLIC;
@@ -5393,7 +5427,7 @@ GRANT ALL ON FUNCTION maevsi.account_email_address_verification(code uuid) TO ma
 
 
 --
--- Name: FUNCTION account_password_change(password_current text, password_new text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_change(password_current text, password_new text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_password_change(password_current text, password_new text) FROM PUBLIC;
@@ -5401,7 +5435,7 @@ GRANT ALL ON FUNCTION maevsi.account_password_change(password_current text, pass
 
 
 --
--- Name: FUNCTION account_password_reset(code uuid, password text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_reset(code uuid, password text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_password_reset(code uuid, password text) FROM PUBLIC;
@@ -5410,7 +5444,7 @@ GRANT ALL ON FUNCTION maevsi.account_password_reset(code uuid, password text) TO
 
 
 --
--- Name: FUNCTION account_password_reset_request(email_address text, language text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_password_reset_request(email_address text, language text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_password_reset_request(email_address text, language text) FROM PUBLIC;
@@ -5419,7 +5453,7 @@ GRANT ALL ON FUNCTION maevsi.account_password_reset_request(email_address text, 
 
 
 --
--- Name: FUNCTION account_registration(username text, email_address text, password text, language text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_registration(username text, email_address text, password text, language text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_registration(username text, email_address text, password text, language text) FROM PUBLIC;
@@ -5428,7 +5462,7 @@ GRANT ALL ON FUNCTION maevsi.account_registration(username text, email_address t
 
 
 --
--- Name: FUNCTION account_registration_refresh(account_id uuid, language text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_registration_refresh(account_id uuid, language text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_registration_refresh(account_id uuid, language text) FROM PUBLIC;
@@ -5436,7 +5470,7 @@ GRANT ALL ON FUNCTION maevsi.account_registration_refresh(account_id uuid, langu
 
 
 --
--- Name: FUNCTION account_upload_quota_bytes(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION account_upload_quota_bytes(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.account_upload_quota_bytes() FROM PUBLIC;
@@ -5444,7 +5478,7 @@ GRANT ALL ON FUNCTION maevsi.account_upload_quota_bytes() TO maevsi_account;
 
 
 --
--- Name: FUNCTION achievement_unlock(code uuid, alias text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION achievement_unlock(code uuid, alias text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.achievement_unlock(code uuid, alias text) FROM PUBLIC;
@@ -5452,21 +5486,21 @@ GRANT ALL ON FUNCTION maevsi.achievement_unlock(code uuid, alias text) TO maevsi
 
 
 --
--- Name: FUNCTION armor(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION armor(bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.armor(bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION armor(bytea, text[], text[]); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION armor(bytea, text[], text[]); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.armor(bytea, text[], text[]) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION authenticate(username text, password text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION authenticate(username text, password text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.authenticate(username text, password text) FROM PUBLIC;
@@ -5475,63 +5509,63 @@ GRANT ALL ON FUNCTION maevsi.authenticate(username text, password text) TO maevs
 
 
 --
--- Name: FUNCTION crypt(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION crypt(text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.crypt(text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION dearmor(text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION dearmor(text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.dearmor(text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION decrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION decrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.decrypt(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION decrypt_iv(bytea, bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION decrypt_iv(bytea, bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.decrypt_iv(bytea, bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION digest(bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION digest(bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.digest(bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION digest(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION digest(text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.digest(text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION encrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION encrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.encrypt(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION encrypt_iv(bytea, bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION encrypt_iv(bytea, bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.encrypt_iv(bytea, bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: TABLE event; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.event TO maevsi_account;
@@ -5539,7 +5573,7 @@ GRANT SELECT ON TABLE maevsi.event TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION event_delete(id uuid, password text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_delete(id uuid, password text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.event_delete(id uuid, password text) FROM PUBLIC;
@@ -5547,7 +5581,7 @@ GRANT ALL ON FUNCTION maevsi.event_delete(id uuid, password text) TO maevsi_acco
 
 
 --
--- Name: FUNCTION event_invitee_count_maximum(event_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_invitee_count_maximum(event_id uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) FROM PUBLIC;
@@ -5556,7 +5590,7 @@ GRANT ALL ON FUNCTION maevsi.event_invitee_count_maximum(event_id uuid) TO maevs
 
 
 --
--- Name: FUNCTION event_is_existing(author_account_id uuid, slug text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_is_existing(author_account_id uuid, slug text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text) FROM PUBLIC;
@@ -5565,7 +5599,7 @@ GRANT ALL ON FUNCTION maevsi.event_is_existing(author_account_id uuid, slug text
 
 
 --
--- Name: FUNCTION event_unlock(invitation_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION event_unlock(invitation_id uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.event_unlock(invitation_id uuid) FROM PUBLIC;
@@ -5574,7 +5608,7 @@ GRANT ALL ON FUNCTION maevsi.event_unlock(invitation_id uuid) TO maevsi_anonymou
 
 
 --
--- Name: FUNCTION events_organized(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION events_organized(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.events_organized() FROM PUBLIC;
@@ -5583,49 +5617,49 @@ GRANT ALL ON FUNCTION maevsi.events_organized() TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION gen_random_bytes(integer); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION gen_random_bytes(integer); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.gen_random_bytes(integer) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION gen_random_uuid(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION gen_random_uuid(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.gen_random_uuid() FROM PUBLIC;
 
 
 --
--- Name: FUNCTION gen_salt(text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION gen_salt(text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.gen_salt(text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION gen_salt(text, integer); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION gen_salt(text, integer); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.gen_salt(text, integer) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION hmac(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION hmac(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.hmac(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION hmac(text, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION hmac(text, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.hmac(text, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION invitation_claim_array(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitation_claim_array(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.invitation_claim_array() FROM PUBLIC;
@@ -5634,7 +5668,7 @@ GRANT ALL ON FUNCTION maevsi.invitation_claim_array() TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION invitation_contact_ids(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitation_contact_ids(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.invitation_contact_ids() FROM PUBLIC;
@@ -5643,7 +5677,7 @@ GRANT ALL ON FUNCTION maevsi.invitation_contact_ids() TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION invite(invitation_id uuid, language text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invite(invitation_id uuid, language text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.invite(invitation_id uuid, language text) FROM PUBLIC;
@@ -5651,7 +5685,7 @@ GRANT ALL ON FUNCTION maevsi.invite(invitation_id uuid, language text) TO maevsi
 
 
 --
--- Name: FUNCTION invitee_count(event_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invitee_count(event_id uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.invitee_count(event_id uuid) FROM PUBLIC;
@@ -5660,7 +5694,7 @@ GRANT ALL ON FUNCTION maevsi.invitee_count(event_id uuid) TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION invoker_account_id(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION invoker_account_id(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.invoker_account_id() FROM PUBLIC;
@@ -5670,7 +5704,7 @@ GRANT ALL ON FUNCTION maevsi.invoker_account_id() TO maevsi_tusd;
 
 
 --
--- Name: FUNCTION jwt_refresh(jwt_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION jwt_refresh(jwt_id uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.jwt_refresh(jwt_id uuid) FROM PUBLIC;
@@ -5679,14 +5713,14 @@ GRANT ALL ON FUNCTION maevsi.jwt_refresh(jwt_id uuid) TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION legal_term_change(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION legal_term_change(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.legal_term_change() FROM PUBLIC;
 
 
 --
--- Name: FUNCTION notification_acknowledge(id uuid, is_acknowledged boolean); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION notification_acknowledge(id uuid, is_acknowledged boolean); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged boolean) FROM PUBLIC;
@@ -5694,147 +5728,147 @@ GRANT ALL ON FUNCTION maevsi.notification_acknowledge(id uuid, is_acknowledged b
 
 
 --
--- Name: FUNCTION pgp_armor_headers(text, OUT key text, OUT value text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_armor_headers(text, OUT key text, OUT value text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_armor_headers(text, OUT key text, OUT value text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_key_id(bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_key_id(bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_key_id(bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt(bytea, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt(bytea, bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt(bytea, bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt(bytea, bytea, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt(bytea, bytea, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt(bytea, bytea, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt_bytea(bytea, bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt_bytea(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_decrypt_bytea(bytea, bytea, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_decrypt_bytea(bytea, bytea, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_encrypt(text, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_encrypt(text, bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_encrypt(text, bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_encrypt(text, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_encrypt(text, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_encrypt(text, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_encrypt_bytea(bytea, bytea); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_encrypt_bytea(bytea, bytea); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_encrypt_bytea(bytea, bytea) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_pub_encrypt_bytea(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_pub_encrypt_bytea(bytea, bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_pub_encrypt_bytea(bytea, bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_decrypt(bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_decrypt(bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_decrypt(bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_decrypt(bytea, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_decrypt(bytea, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_decrypt(bytea, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_decrypt_bytea(bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_decrypt_bytea(bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_decrypt_bytea(bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_decrypt_bytea(bytea, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_decrypt_bytea(bytea, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_decrypt_bytea(bytea, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_encrypt(text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_encrypt(text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_encrypt(text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_encrypt(text, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_encrypt(text, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_encrypt(text, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_encrypt_bytea(bytea, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_encrypt_bytea(bytea, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_encrypt_bytea(bytea, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION pgp_sym_encrypt_bytea(bytea, text, text); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION pgp_sym_encrypt_bytea(bytea, text, text); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.pgp_sym_encrypt_bytea(bytea, text, text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION profile_picture_set(upload_id uuid); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION profile_picture_set(upload_id uuid); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.profile_picture_set(upload_id uuid) FROM PUBLIC;
@@ -5842,7 +5876,7 @@ GRANT ALL ON FUNCTION maevsi.profile_picture_set(upload_id uuid) TO maevsi_accou
 
 
 --
--- Name: FUNCTION trigger_contact_update_account_id(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION trigger_contact_update_account_id(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.trigger_contact_update_account_id() FROM PUBLIC;
@@ -5850,7 +5884,7 @@ GRANT ALL ON FUNCTION maevsi.trigger_contact_update_account_id() TO maevsi_accou
 
 
 --
--- Name: FUNCTION trigger_invitation_update(); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION trigger_invitation_update(); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.trigger_invitation_update() FROM PUBLIC;
@@ -5859,7 +5893,7 @@ GRANT ALL ON FUNCTION maevsi.trigger_invitation_update() TO maevsi_anonymous;
 
 
 --
--- Name: TABLE upload; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE upload; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.upload TO maevsi_account;
@@ -5868,7 +5902,7 @@ GRANT SELECT,DELETE,UPDATE ON TABLE maevsi.upload TO maevsi_tusd;
 
 
 --
--- Name: FUNCTION upload_create(size_byte bigint); Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: FUNCTION upload_create(size_byte bigint); Type: ACL; Schema: maevsi; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi.upload_create(size_byte bigint) FROM PUBLIC;
@@ -5876,7 +5910,7 @@ GRANT ALL ON FUNCTION maevsi.upload_create(size_byte bigint) TO maevsi_account;
 
 
 --
--- Name: FUNCTION account_block_ids(); Type: ACL; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_block_ids(); Type: ACL; Schema: maevsi_private; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_private.account_block_ids() FROM PUBLIC;
@@ -5885,7 +5919,7 @@ GRANT ALL ON FUNCTION maevsi_private.account_block_ids() TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION account_email_address_verification_valid_until(); Type: ACL; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_email_address_verification_valid_until(); Type: ACL; Schema: maevsi_private; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_private.account_email_address_verification_valid_until() FROM PUBLIC;
@@ -5893,7 +5927,7 @@ GRANT ALL ON FUNCTION maevsi_private.account_email_address_verification_valid_un
 
 
 --
--- Name: FUNCTION account_password_reset_verification_valid_until(); Type: ACL; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION account_password_reset_verification_valid_until(); Type: ACL; Schema: maevsi_private; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_private.account_password_reset_verification_valid_until() FROM PUBLIC;
@@ -5901,7 +5935,7 @@ GRANT ALL ON FUNCTION maevsi_private.account_password_reset_verification_valid_u
 
 
 --
--- Name: FUNCTION events_invited(); Type: ACL; Schema: maevsi_private; Owner: postgres
+-- Name: FUNCTION events_invited(); Type: ACL; Schema: maevsi_private; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_private.events_invited() FROM PUBLIC;
@@ -5910,119 +5944,128 @@ GRANT ALL ON FUNCTION maevsi_private.events_invited() TO maevsi_anonymous;
 
 
 --
--- Name: FUNCTION account_block_create(_author_account_id uuid, _blocked_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION account_block_create(_author_account_id uuid, _blocked_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.account_block_create(_author_account_id uuid, _blocked_account_id uuid) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION account_block_remove(_author_account_id uuid, _blocked_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION account_block_remove(_author_account_id uuid, _blocked_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.account_block_remove(_author_account_id uuid, _blocked_account_id uuid) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION account_create(_username text, _email text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION account_create(_username text, _email text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.account_create(_username text, _email text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION account_remove(_username text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION account_remove(_username text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.account_remove(_username text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION contact_create(_author_account_id uuid, _email_address text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION contact_create(_author_account_id uuid, _email_address text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.contact_create(_author_account_id uuid, _email_address text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION contact_select_by_account_id(_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION contact_select_by_account_id(_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.contact_select_by_account_id(_account_id uuid) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION contact_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION contact_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.contact_test(_test_case text, _account_id uuid, _expected_result uuid[]) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION event_category_create(_category text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION event_category_create(_category text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.event_category_create(_category text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.event_category_mapping_create(_author_account_id uuid, _event_id uuid, _category text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.event_category_mapping_test(_test_case text, _account_id uuid, _expected_result uuid[]) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.event_create(_author_account_id uuid, _name text, _slug text, _start text, _visibility text) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION event_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION event_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.event_test(_test_case text, _account_id uuid, _expected_result uuid[]) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION invitation_claim_from_account_invitation(_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION invitation_claim_from_account_invitation(_account_id uuid); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.invitation_claim_from_account_invitation(_account_id uuid) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.invitation_create(_author_account_id uuid, _event_id uuid, _contact_id uuid) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) FROM PUBLIC;
 
 
 --
--- Name: FUNCTION uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]); Type: ACL; Schema: maevsi_test; Owner: postgres
+-- Name: FUNCTION set_local_superuser(); Type: ACL; Schema: maevsi_test; Owner: ci
+--
+
+REVOKE ALL ON FUNCTION maevsi_test.set_local_superuser() FROM PUBLIC;
+GRANT ALL ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_anonymous;
+GRANT ALL ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_account;
+
+
+--
+-- Name: FUNCTION uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
 REVOKE ALL ON FUNCTION maevsi_test.uuid_array_test(_test_case text, _array uuid[], _expected_array uuid[]) FROM PUBLIC;
 
 
 --
--- Name: TABLE account; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE account; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.account TO maevsi_account;
@@ -6030,7 +6073,7 @@ GRANT SELECT ON TABLE maevsi.account TO maevsi_anonymous;
 
 
 --
--- Name: TABLE account_block; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_block; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT ON TABLE maevsi.account_block TO maevsi_account;
@@ -6038,21 +6081,21 @@ GRANT SELECT ON TABLE maevsi.account_block TO maevsi_anonymous;
 
 
 --
--- Name: TABLE account_interest; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_interest; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE maevsi.account_interest TO maevsi_account;
 
 
 --
--- Name: TABLE account_preference_event_size; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_preference_event_size; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE maevsi.account_preference_event_size TO maevsi_account;
 
 
 --
--- Name: TABLE account_social_network; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE account_social_network; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.account_social_network TO maevsi_anonymous;
@@ -6060,7 +6103,7 @@ GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.account_social_network TO maev
 
 
 --
--- Name: TABLE achievement; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE achievement; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.achievement TO maevsi_account;
@@ -6068,7 +6111,7 @@ GRANT SELECT ON TABLE maevsi.achievement TO maevsi_anonymous;
 
 
 --
--- Name: TABLE contact; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE contact; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.contact TO maevsi_account;
@@ -6076,7 +6119,7 @@ GRANT SELECT ON TABLE maevsi.contact TO maevsi_anonymous;
 
 
 --
--- Name: TABLE event_category; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_category; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.event_category TO maevsi_anonymous;
@@ -6084,7 +6127,7 @@ GRANT SELECT ON TABLE maevsi.event_category TO maevsi_account;
 
 
 --
--- Name: TABLE event_category_mapping; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_category_mapping; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.event_category_mapping TO maevsi_anonymous;
@@ -6092,14 +6135,14 @@ GRANT SELECT,INSERT,DELETE ON TABLE maevsi.event_category_mapping TO maevsi_acco
 
 
 --
--- Name: TABLE event_favourite; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_favourite; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE maevsi.event_favourite TO maevsi_account;
 
 
 --
--- Name: TABLE event_group; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_group; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.event_group TO maevsi_account;
@@ -6107,7 +6150,7 @@ GRANT SELECT ON TABLE maevsi.event_group TO maevsi_anonymous;
 
 
 --
--- Name: TABLE event_grouping; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_grouping; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.event_grouping TO maevsi_account;
@@ -6115,14 +6158,14 @@ GRANT SELECT ON TABLE maevsi.event_grouping TO maevsi_anonymous;
 
 
 --
--- Name: TABLE event_recommendation; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_recommendation; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE maevsi.event_recommendation TO maevsi_account;
 
 
 --
--- Name: TABLE event_upload; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE event_upload; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE maevsi.event_upload TO maevsi_account;
@@ -6130,7 +6173,7 @@ GRANT SELECT ON TABLE maevsi.event_upload TO maevsi_anonymous;
 
 
 --
--- Name: TABLE invitation; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE invitation; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.invitation TO maevsi_account;
@@ -6138,7 +6181,7 @@ GRANT SELECT,UPDATE ON TABLE maevsi.invitation TO maevsi_anonymous;
 
 
 --
--- Name: TABLE invitation_flat; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE invitation_flat; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.invitation_flat TO maevsi_account;
@@ -6146,7 +6189,7 @@ GRANT SELECT ON TABLE maevsi.invitation_flat TO maevsi_anonymous;
 
 
 --
--- Name: TABLE legal_term; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE legal_term; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi.legal_term TO maevsi_account;
@@ -6154,14 +6197,14 @@ GRANT SELECT ON TABLE maevsi.legal_term TO maevsi_anonymous;
 
 
 --
--- Name: TABLE legal_term_acceptance; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE legal_term_acceptance; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT ON TABLE maevsi.legal_term_acceptance TO maevsi_account;
 
 
 --
--- Name: TABLE profile_picture; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE profile_picture; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE maevsi.profile_picture TO maevsi_account;
@@ -6170,24 +6213,24 @@ GRANT SELECT,DELETE ON TABLE maevsi.profile_picture TO maevsi_tusd;
 
 
 --
--- Name: TABLE report; Type: ACL; Schema: maevsi; Owner: postgres
+-- Name: TABLE report; Type: ACL; Schema: maevsi; Owner: ci
 --
 
 GRANT SELECT,INSERT ON TABLE maevsi.report TO maevsi_account;
 
 
 --
--- Name: TABLE achievement_code; Type: ACL; Schema: maevsi_private; Owner: postgres
+-- Name: TABLE achievement_code; Type: ACL; Schema: maevsi_private; Owner: ci
 --
 
 GRANT SELECT ON TABLE maevsi_private.achievement_code TO maevsi_tusd;
 
 
 --
--- Name: DEFAULT PRIVILEGES FOR FUNCTIONS; Type: DEFAULT ACL; Schema: -; Owner: postgres
+-- Name: DEFAULT PRIVILEGES FOR FUNCTIONS; Type: DEFAULT ACL; Schema: -; Owner: ci
 --
 
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres REVOKE ALL ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE ci REVOKE ALL ON FUNCTIONS FROM PUBLIC;
 
 
 --

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -1795,7 +1795,7 @@ BEGIN
   VALUES (_author_account_id, _blocked_Account_id)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
@@ -1866,7 +1866,7 @@ BEGIN
 
     PERFORM maevsi.account_delete('password');
 
-    PERFORM maevsi_test.set_local_superuser();
+    CALL maevsi_test.set_local_superuser();
   END IF;
 END $$;
 
@@ -1897,7 +1897,7 @@ BEGIN
     UPDATE maevsi.contact SET account_id = _account_id WHERE id = _id;
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
@@ -1951,7 +1951,7 @@ BEGIN
     RAISE EXCEPTION 'some contact is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$;
 
 
@@ -1985,7 +1985,7 @@ BEGIN
   INSERT INTO maevsi.event_category_mapping(event_id, category)
   VALUES (_event_id, _category);
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$;
 
 
@@ -2015,7 +2015,7 @@ BEGIN
     RAISE EXCEPTION 'some event_category_mappings is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$;
 
 
@@ -2038,7 +2038,7 @@ BEGIN
   VALUES (_author_account_id, _name, _slug, _start::TIMESTAMP WITH TIME ZONE, _visibility::maevsi.event_visibility)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
@@ -2070,7 +2070,7 @@ BEGIN
     RAISE EXCEPTION 'some event is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$;
 
 
@@ -2111,7 +2111,7 @@ BEGIN
 
   EXECUTE 'SET LOCAL jwt.claims.invitations = ''[' || _text || ']''';
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _result;
 END $$;
@@ -2136,7 +2136,7 @@ BEGIN
   VALUES (_contact_id, _event_id)
   RETURNING id INTO _id;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 
   RETURN _id;
 END $$;
@@ -2168,21 +2168,21 @@ BEGIN
     RAISE EXCEPTION 'some invitation is missing in the query result';
   END IF;
 
-  PERFORM maevsi_test.set_local_superuser();
+  CALL maevsi_test.set_local_superuser();
 END $$;
 
 
 ALTER FUNCTION maevsi_test.invitation_test(_test_case text, _account_id uuid, _expected_result uuid[]) OWNER TO ci;
 
 --
--- Name: set_local_superuser(); Type: FUNCTION; Schema: maevsi_test; Owner: ci
+-- Name: set_local_superuser(); Type: PROCEDURE; Schema: maevsi_test; Owner: ci
 --
 
-CREATE FUNCTION maevsi_test.set_local_superuser() RETURNS void
+CREATE PROCEDURE maevsi_test.set_local_superuser()
     LANGUAGE plpgsql
     AS $$
 DECLARE
-    _superuser_name TEXT;
+  _superuser_name TEXT;
 BEGIN
   SELECT usename INTO _superuser_name
   FROM pg_user
@@ -2198,7 +2198,7 @@ BEGIN
 END $$;
 
 
-ALTER FUNCTION maevsi_test.set_local_superuser() OWNER TO ci;
+ALTER PROCEDURE maevsi_test.set_local_superuser() OWNER TO ci;
 
 --
 -- Name: uuid_array_test(text, uuid[], uuid[]); Type: FUNCTION; Schema: maevsi_test; Owner: ci
@@ -6049,12 +6049,12 @@ REVOKE ALL ON FUNCTION maevsi_test.invitation_test(_test_case text, _account_id 
 
 
 --
--- Name: FUNCTION set_local_superuser(); Type: ACL; Schema: maevsi_test; Owner: ci
+-- Name: PROCEDURE set_local_superuser(); Type: ACL; Schema: maevsi_test; Owner: ci
 --
 
-REVOKE ALL ON FUNCTION maevsi_test.set_local_superuser() FROM PUBLIC;
-GRANT ALL ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_anonymous;
-GRANT ALL ON FUNCTION maevsi_test.set_local_superuser() TO maevsi_account;
+REVOKE ALL ON PROCEDURE maevsi_test.set_local_superuser() FROM PUBLIC;
+GRANT ALL ON PROCEDURE maevsi_test.set_local_superuser() TO maevsi_anonymous;
+GRANT ALL ON PROCEDURE maevsi_test.set_local_superuser() TO maevsi_account;
 
 
 --


### PR DESCRIPTION
The superuser username should stay flexible to allow for a different username in production. This PR customizes the CI's superuser username so that it's obvious that it's not meant to be hardcoded in the migrations.