### PR TITLE
refactor(role)!: rename for services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,11 @@ RUN apt-get update \
     sqitch=1.1.0000-1 \
   && mkdir -p /run/secrets \
   && echo "postgres"      > /run/secrets/postgres_password \
-  && echo "postgraphile"  > /run/secrets/postgres_role_postgraphile_username \
-  && echo "vibetype"          > /run/secrets/postgres_role_vibetype_username \
+  && echo "postgraphile"  > /run/secrets/postgres_role_service_postgraphile_username \
+  && echo "vibetype"          > /run/secrets/postgres_role_service_vibetype_username \
   && echo "placeholder" | tee \
-    /run/secrets/postgres_role_vibetype_password \
-    /run/secrets/postgres_role_postgraphile_password \
+    /run/secrets/postgres_role_service_vibetype_password \
+    /run/secrets/postgres_role_service_postgraphile_password \
     /dev/null
 
 COPY ./src ./

--- a/src/deploy/function_invoker_account_id.sql
+++ b/src/deploy/function_invoker_account_id.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
 CREATE FUNCTION vibetype.invoker_account_id() RETURNS UUID AS $$
 BEGIN
@@ -10,6 +10,6 @@ $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER STABLE;
 
 COMMENT ON FUNCTION vibetype.invoker_account_id() IS 'Returns the session''s account id.';
 
-GRANT EXECUTE ON FUNCTION vibetype.invoker_account_id() TO vibetype_account, vibetype_anonymous, :role_vibetype_username;
+GRANT EXECUTE ON FUNCTION vibetype.invoker_account_id() TO vibetype_account, vibetype_anonymous, :role_service_vibetype_username;
 
 COMMIT;

--- a/src/deploy/role_account.sql
+++ b/src/deploy/role_account.sql
@@ -1,10 +1,10 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
 
 DROP ROLE IF EXISTS vibetype_account;
 CREATE ROLE vibetype_account;
 
-GRANT vibetype_account to :role_postgraphile_username;
+GRANT vibetype_account to :role_service_postgraphile_username;
 
 COMMIT;

--- a/src/deploy/role_anonymous.sql
+++ b/src/deploy/role_anonymous.sql
@@ -1,10 +1,10 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
 
 DROP ROLE IF EXISTS vibetype_anonymous;
 CREATE ROLE vibetype_anonymous;
 
-GRANT vibetype_anonymous to :role_postgraphile_username;
+GRANT vibetype_anonymous to :role_service_postgraphile_username;
 
 COMMIT;

--- a/src/deploy/role_postgraphile.sql
+++ b/src/deploy/role_postgraphile.sql
@@ -1,9 +1,9 @@
 BEGIN;
 
-\set role_postgraphile_password `cat /run/secrets/postgres_role_postgraphile_password`
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
+\set role_service_postgraphile_password `cat /run/secrets/postgres_role_service_postgraphile_password`
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
 
-DROP ROLE IF EXISTS :role_postgraphile_username;
-CREATE ROLE :role_postgraphile_username LOGIN PASSWORD :'role_postgraphile_password';
+DROP ROLE IF EXISTS :role_service_postgraphile_username;
+CREATE ROLE :role_service_postgraphile_username LOGIN PASSWORD :'role_service_postgraphile_password';
 
 COMMIT;

--- a/src/deploy/role_vibetype.sql
+++ b/src/deploy/role_vibetype.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
-\set role_vibetype_password `cat /run/secrets/postgres_role_vibetype_password`
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
+\set role_service_vibetype_password `cat /run/secrets/postgres_role_service_vibetype_password`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
 
-DROP ROLE IF EXISTS :role_vibetype_username;
-CREATE ROLE :role_vibetype_username LOGIN PASSWORD :'role_vibetype_password';
+DROP ROLE IF EXISTS :role_service_vibetype_username;
+CREATE ROLE :role_service_vibetype_username LOGIN PASSWORD :'role_service_vibetype_password';
 
-GRANT :role_vibetype_username TO :role_postgraphile_username;
+GRANT :role_service_vibetype_username TO :role_service_postgraphile_username;
 
 COMMIT;

--- a/src/deploy/schema_public.sql
+++ b/src/deploy/schema_public.sql
@@ -1,11 +1,11 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
 CREATE SCHEMA vibetype;
 
 COMMENT ON SCHEMA vibetype IS 'Is used by PostGraphile.';
 
-GRANT USAGE ON SCHEMA vibetype TO vibetype_anonymous, vibetype_account, :role_vibetype_username;
+GRANT USAGE ON SCHEMA vibetype TO vibetype_anonymous, vibetype_account, :role_service_vibetype_username;
 
 COMMIT;

--- a/src/deploy/table_achievement_code.sql
+++ b/src/deploy/table_achievement_code.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
 CREATE TABLE vibetype_private.achievement_code (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -14,7 +14,7 @@ COMMENT ON COLUMN vibetype_private.achievement_code.id IS 'The code that unlocks
 COMMENT ON COLUMN vibetype_private.achievement_code.alias IS 'An alternative code, e.g. human readable, that unlocks an achievement.';
 COMMENT ON COLUMN vibetype_private.achievement_code.achievement IS 'The achievement that is unlocked by the code.';
 
-GRANT SELECT ON TABLE vibetype_private.achievement_code TO :role_vibetype_username;
+GRANT SELECT ON TABLE vibetype_private.achievement_code TO :role_service_vibetype_username;
 
 ALTER TABLE vibetype_private.achievement_code ENABLE ROW LEVEL SECURITY;
 

--- a/src/deploy/table_profile_picture.sql
+++ b/src/deploy/table_profile_picture.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
 CREATE TABLE vibetype.profile_picture (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -14,9 +14,9 @@ COMMENT ON COLUMN vibetype.profile_picture.id IS E'@omit create,update\nThe prof
 COMMENT ON COLUMN vibetype.profile_picture.account_id IS 'The account''s id.';
 COMMENT ON COLUMN vibetype.profile_picture.upload_id IS 'The upload''s id.';
 
-GRANT SELECT ON TABLE vibetype.profile_picture TO vibetype_account, vibetype_anonymous, :role_vibetype_username;
+GRANT SELECT ON TABLE vibetype.profile_picture TO vibetype_account, vibetype_anonymous, :role_service_vibetype_username;
 GRANT INSERT, DELETE, UPDATE ON TABLE vibetype.profile_picture TO vibetype_account;
-GRANT DELETE ON TABLE vibetype.profile_picture TO :role_vibetype_username;
+GRANT DELETE ON TABLE vibetype.profile_picture TO :role_service_vibetype_username;
 
 ALTER TABLE vibetype.profile_picture ENABLE ROW LEVEL SECURITY;
 
@@ -41,7 +41,7 @@ CREATE POLICY profile_picture_update ON vibetype.profile_picture FOR UPDATE USIN
 
 -- Only allow deletes for the item with the account id that matches the invoker's account id.
 CREATE POLICY profile_picture_delete ON vibetype.profile_picture FOR DELETE USING (
-    (SELECT current_user) = :'role_vibetype_username'
+    (SELECT current_user) = :'role_service_vibetype_username'
   OR
     (
       vibetype.invoker_account_id() IS NOT NULL

--- a/src/deploy/table_upload_policy.sql
+++ b/src/deploy/table_upload_policy.sql
@@ -1,10 +1,10 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
-GRANT SELECT ON TABLE vibetype.upload TO vibetype_account, vibetype_anonymous, :role_vibetype_username;
-GRANT UPDATE ON TABLE vibetype.upload TO :role_vibetype_username;
-GRANT DELETE ON TABLE vibetype.upload TO :role_vibetype_username;
+GRANT SELECT ON TABLE vibetype.upload TO vibetype_account, vibetype_anonymous, :role_service_vibetype_username;
+GRANT UPDATE ON TABLE vibetype.upload TO :role_service_vibetype_username;
+GRANT DELETE ON TABLE vibetype.upload TO :role_service_vibetype_username;
 
 ALTER TABLE vibetype.upload ENABLE ROW LEVEL SECURITY;
 
@@ -13,7 +13,7 @@ ALTER TABLE vibetype.upload ENABLE ROW LEVEL SECURITY;
 -- - the uploads that are linked to the requesting account or
 -- - the uploads which are used as profile picture.
 CREATE POLICY upload_select_using ON vibetype.upload FOR SELECT USING (
-    (SELECT current_user) = :'role_vibetype_username'
+    (SELECT current_user) = :'role_service_vibetype_username'
   OR
     (
       vibetype.invoker_account_id() IS NOT NULL
@@ -26,12 +26,12 @@ CREATE POLICY upload_select_using ON vibetype.upload FOR SELECT USING (
 
 -- Only allow the server to update rows.
 CREATE POLICY upload_update_using ON vibetype.upload FOR UPDATE USING (
-  (SELECT current_user) = :'role_vibetype_username'
+  (SELECT current_user) = :'role_service_vibetype_username'
 );
 
 -- Only allow the server to delete rows.
 CREATE POLICY upload_delete_using ON vibetype.upload FOR DELETE USING (
-  (SELECT current_user) = :'role_vibetype_username'
+  (SELECT current_user) = :'role_service_vibetype_username'
 );
 
 COMMIT;

--- a/src/revert/role_postgraphile.sql
+++ b/src/revert/role_postgraphile.sql
@@ -1,8 +1,8 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
 
-DROP OWNED BY :role_postgraphile_username;
-DROP ROLE :role_postgraphile_username;
+DROP OWNED BY :role_service_postgraphile_username;
+DROP ROLE :role_service_postgraphile_username;
 
 COMMIT;

--- a/src/revert/role_vibetype.sql
+++ b/src/revert/role_vibetype.sql
@@ -1,8 +1,8 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
 
-DROP OWNED BY :role_vibetype_username;
-DROP ROLE :role_vibetype_username;
+DROP OWNED BY :role_service_vibetype_username;
+DROP ROLE :role_service_vibetype_username;
 
 COMMIT;

--- a/src/sqitch
+++ b/src/sqitch
@@ -69,8 +69,8 @@ fi
 docker run --rm --network host \
     --mount "type=bind,src=$(pwd),dst=/repo" \
     --mount "type=bind,src=$HOME,dst=$homedst" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_vibetype_password.secret,dst=/run/secrets/postgres_role_vibetype_password" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_vibetype_username.secret,dst=/run/secrets/postgres_role_vibetype_username" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_password.secret,dst=/run/secrets/postgres_role_postgraphile_password" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_username.secret,dst=/run/secrets/postgres_role_postgraphile_username" \
+    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_service_vibetype_password.secret,dst=/run/secrets/postgres_role_service_vibetype_password" \
+    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_service_vibetype_username.secret,dst=/run/secrets/postgres_role_service_vibetype_username" \
+    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_service_postgraphile_password.secret,dst=/run/secrets/postgres_role_service_postgraphile_password" \
+    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_service_postgraphile_username.secret,dst=/run/secrets/postgres_role_service_postgraphile_username" \
     "${passopt[@]}" "$SQITCH_IMAGE" "$@"

--- a/src/verify/function_invoker_account_id.sql
+++ b/src/verify/function_invoker_account_id.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/role_account.sql
+++ b/src/verify/role_account.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
-SET local role.vibetype_postgraphile_username TO :'role_postgraphile_username';
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
+SET local role.vibetype_postgraphile_username TO :'role_service_postgraphile_username';
 
 DO $$
 BEGIN

--- a/src/verify/role_anonymous.sql
+++ b/src/verify/role_anonymous.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
-SET local role.vibetype_postgraphile_username TO :'role_postgraphile_username';
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
+SET local role.vibetype_postgraphile_username TO :'role_service_postgraphile_username';
 
 DO $$
 BEGIN

--- a/src/verify/role_postgraphile.sql
+++ b/src/verify/role_postgraphile.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_postgraphile_username `cat /run/secrets/postgres_role_postgraphile_username`
-SET local role.vibetype_postgraphile_username TO :'role_postgraphile_username';
+\set role_service_postgraphile_username `cat /run/secrets/postgres_role_service_postgraphile_username`
+SET local role.vibetype_postgraphile_username TO :'role_service_postgraphile_username';
 
 DO $$
 BEGIN

--- a/src/verify/role_vibetype.sql
+++ b/src/verify/role_vibetype.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/schema_public.sql
+++ b/src/verify/schema_public.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_account_block_policy.sql
+++ b/src/verify/table_account_block_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_account_interest_policy.sql
+++ b/src/verify/table_account_interest_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_account_preference_event_size_policy.sql
+++ b/src/verify/table_account_preference_event_size_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_account_private.sql
+++ b/src/verify/table_account_private.sql
@@ -19,8 +19,8 @@ SELECT vibetype_test.index_existence(
   'vibetype_private'
 );
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_account_public.sql
+++ b/src/verify/table_account_public.sql
@@ -4,8 +4,8 @@ SELECT id,
        username
 FROM vibetype.account WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_achievement.sql
+++ b/src/verify/table_achievement.sql
@@ -6,8 +6,8 @@ SELECT id,
        level
 FROM vibetype.achievement WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_achievement_code.sql
+++ b/src/verify/table_achievement_code.sql
@@ -5,8 +5,8 @@ SELECT id,
        achievement
 FROM vibetype_private.achievement_code WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_address_policy.sql
+++ b/src/verify/table_address_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_contact_policy.sql
+++ b/src/verify/table_contact_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_device_policy.sql
+++ b/src/verify/table_device_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_category_mapping_policy.sql
+++ b/src/verify/table_event_category_mapping_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_category_policy.sql
+++ b/src/verify/table_event_category_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_favorite_policy.sql
+++ b/src/verify/table_event_favorite_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_group.sql
+++ b/src/verify/table_event_group.sql
@@ -13,8 +13,8 @@ SELECT vibetype_test.index_existence(
   ARRAY ['event_group_created_by_slug_key']
 );
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_grouping.sql
+++ b/src/verify/table_event_grouping.sql
@@ -9,8 +9,8 @@ SELECT vibetype_test.index_existence(
   ARRAY ['event_grouping_event_id_event_group_id_key']
 );
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_policy.sql
+++ b/src/verify/table_event_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_recommendation_policy.sql
+++ b/src/verify/table_event_recommendation_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_event_upload_policy.sql
+++ b/src/verify/table_event_upload_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_friendship_policy.sql
+++ b/src/verify/table_friendship_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_guest_policy.sql
+++ b/src/verify/table_guest_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_jwt.sql
+++ b/src/verify/table_jwt.sql
@@ -4,8 +4,8 @@ SELECT id,
        token
 FROM vibetype_private.jwt WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_legal_term.sql
+++ b/src/verify/table_legal_term.sql
@@ -7,8 +7,8 @@ SELECT id,
        created_at
 FROM vibetype.legal_term WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_legal_term_acceptance.sql
+++ b/src/verify/table_legal_term_acceptance.sql
@@ -6,8 +6,8 @@ SELECT id,
        created_at
 FROM vibetype.legal_term_acceptance WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_profile_picture.sql
+++ b/src/verify/table_profile_picture.sql
@@ -5,8 +5,8 @@ SELECT id,
        upload_id
 FROM vibetype.profile_picture WHERE FALSE;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_report_policy.sql
+++ b/src/verify/table_report_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN

--- a/src/verify/table_upload_policy.sql
+++ b/src/verify/table_upload_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
-SET local role.vibetype_username TO :'role_vibetype_username';
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
 
 DO $$
 BEGIN


### PR DESCRIPTION
To make it more clear which roles belong to services connecting to the database, the word "service" is added to these role names.

I thought about renaming the `vibetype_account` and `vibetype_anonymous` roles instead but wasn't sure about a fitting name.