### PR TITLE
refactor(environment)!: dissolve target variable file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,7 @@ RUN apt-get update \
 COPY ./src ./
 COPY ./test/index-missing.sql ./test/
 
-RUN export SQITCH_TARGET="$(cat SQITCH_TARGET.env)" \
-  && docker-entrypoint.sh postgres & \
+RUN docker-entrypoint.sh postgres & \
   while ! pg_isready -h localhost -U ci -p 5432; do sleep 1; done \
   && sqitch deploy -t db:pg://ci:postgres@/ci_database \
   && psql -h localhost -U ci -d ci_database -f ./test/index-missing.sql -v ON_ERROR_STOP=on \

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ This diagram shows the structure of Vibetype's database.
 
 You can create this file as follows:
 
-1. configure [maevsi/stack](https://github.com/maevsi/stack) by adding a portforward of `5432:5432` to the `postgres` service
-
 1. start `maevsi/stack`
 
 1. run `docker run -v /run/postgresql/:/run/postgresql/ --network=host --name schemacrawler --rm -i -t --user=0:0 --entrypoint=/bin/bash schemacrawler/schemacrawler`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,15 +1,7 @@
 #!/bin/sh
 set -e
 
-THIS=$(dirname "$(readlink -f "$0")")
-SQITCH_TARGET=''
-
-if [ "$ENV" = "production" ]; then
-    SQITCH_TARGET="$(cat /run/secrets/sqitch_target)"
-else
-    SQITCH_TARGET="$(cat "$THIS/src/SQITCH_TARGET.env")"
-fi
-
+SQITCH_TARGET="$(cat /run/secrets/sqitch_target)"
 export SQITCH_TARGET
 
 exec /bin/sh -c "$*"

--- a/src/SQITCH_TARGET.env
+++ b/src/SQITCH_TARGET.env
@@ -1,1 +1,0 @@
-db:pg://postgres:postgres@/vibetype

--- a/src/sqitch
+++ b/src/sqitch
@@ -4,11 +4,8 @@
 # Determine which Docker image to run.
 SQITCH_IMAGE=${SQITCH_IMAGE:=sqitch/sqitch:latest}
 
-if [ -e "$PWD/SQITCH_TARGET.env" ]
-then
-    SQITCH_TARGET="$(cat "$PWD"/SQITCH_TARGET.env)"
-    export SQITCH_TARGET
-fi
+SQITCH_TARGET="db:pg://postgres:postgres@localhost/vibetype"
+export SQITCH_TARGET
 
 # Set up required pass-through variables.
 user=${USER-$(whoami)}
@@ -46,7 +43,7 @@ for var in \
     TNS_ADMIN TWO_TASK ORACLE_SID \
     ISC_USER ISC_PASSWORD \
     VSQL_HOST VSQL_PORT VSQL_USER VSQL_PASSWORD VSQL_SSLMODE \
-    SNOWSQL_ACCOUNT SNOWSQL_USER SNOWSQL_PWD SNOWSQL_HOST SNOWSQL_PORT SNOWSQL_DATABASE SNOWSQL_REGION SNOWSQL_WAREHOUSE SNOWSQL_PRIVATE_KEY_PASSPHRASE
+    SNOWSQL_ACCOUNT SNOWSQL_USER SNOWSQL_PWD SNOWSQL_HOST SNOWSQL_PORT SNOWSQL_DATABASE SNOWSQL_REGION SNOWSQL_WAREHOUSE SNOWSQL_PRIVATE_KEY_PASSPHRASE SNOWSQL_ROLE
 do
     if [ -n "${!var}" ]; then
        passopt+=(-e "$var")
@@ -76,5 +73,4 @@ docker run --rm --network host \
     --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_vibetype_username.secret,dst=/run/secrets/postgres_role_vibetype_username" \
     --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_password.secret,dst=/run/secrets/postgres_role_postgraphile_password" \
     --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_username.secret,dst=/run/secrets/postgres_role_postgraphile_username" \
-    --mount "type=bind,src=/run/postgresql/,dst=/run/postgresql/" \
     "${passopt[@]}" "$SQITCH_IMAGE" "$@"

--- a/src/sqitch.conf
+++ b/src/sqitch.conf
@@ -3,7 +3,6 @@
 [deploy]
 	verify = true
 [engine "pg"]
-	# Make sure the SQITCH_TARGET environment variable is set as shown in "SQITCH_TARGET.env.template"!
 	target = vibetype
 [rebase]
 	verify = true


### PR DESCRIPTION
Instead of conditional value sourcing, set the correct target specific to the environment.

This allows to connect via port `5432` instead of mounting the socket. The socket would be more private, but overriding host files can lead to some confusion as it also mounts secret files to the host. Other services are exposed via the network too, we may need some general review of the security logic for development here eventually.

Migration guide:
- expose postgres port `5432` for development

cc @HMDank