### PR TITLE
chore(stack): shorten name

### DIFF
--- a/src/sqitch
+++ b/src/sqitch
@@ -72,9 +72,9 @@ fi
 docker run --rm --network host \
     --mount "type=bind,src=$(pwd),dst=/repo" \
     --mount "type=bind,src=$HOME,dst=$homedst" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_vibetype_password.secret,dst=/run/secrets/postgres_role_vibetype_password" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_vibetype_username.secret,dst=/run/secrets/postgres_role_vibetype_username" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_password.secret,dst=/run/secrets/postgres_role_postgraphile_password" \
-    --mount "type=bind,src=$PWD/../../vibetype_stack/src/development/secrets/postgres/role_postgraphile_username.secret,dst=/run/secrets/postgres_role_postgraphile_username" \
+    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_vibetype_password.secret,dst=/run/secrets/postgres_role_vibetype_password" \
+    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_vibetype_username.secret,dst=/run/secrets/postgres_role_vibetype_username" \
+    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_postgraphile_password.secret,dst=/run/secrets/postgres_role_postgraphile_password" \
+    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_postgraphile_username.secret,dst=/run/secrets/postgres_role_postgraphile_username" \
     --mount "type=bind,src=/run/postgresql/,dst=/run/postgresql/" \
     "${passopt[@]}" "$SQITCH_IMAGE" "$@"


### PR DESCRIPTION
@maevsi/contributors-active this change expects the stack directory to be named `stack` instead of `vibetype_stack`. If you're running `sqitch deploy` in your CLI with this commit applied, the directory name must match, if you're just running sqitch inside the stack, you can continue as usual.