### PR TITLE
feat(constraint)!: add `ON DELETE` clauses to foreign keys

### DIFF
--- a/src/deploy/table_account_block.sql
+++ b/src/deploy/table_account_block.sql
@@ -3,10 +3,10 @@ BEGIN;
 CREATE TABLE vibetype.account_block (
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  blocked_account_id  UUID NOT NULL REFERENCES vibetype.account(id),
+  blocked_account_id  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by          UUID NOT NULL REFERENCES vibetype.account(id),
+  created_by          UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   UNIQUE (created_by, blocked_account_id),
   CHECK (created_by != blocked_account_id)

--- a/src/deploy/table_account_preference_event_size.sql
+++ b/src/deploy/table_account_preference_event_size.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE TABLE vibetype.account_preference_event_size (
-  account_id  UUID REFERENCES vibetype.account(id),
+  account_id  UUID REFERENCES vibetype.account(id) ON DELETE CASCADE,
   event_size  vibetype.event_size,
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/deploy/table_achievement.sql
+++ b/src/deploy/table_achievement.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE TABLE vibetype.achievement (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  account_id  UUID NOT NULL REFERENCES vibetype.account(id),
+  account_id  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   achievement vibetype.achievement_type NOT NULL,
   level       INTEGER NOT NULL CHECK (level > 0) DEFAULT 1,
 

--- a/src/deploy/table_address.sql
+++ b/src/deploy/table_address.sql
@@ -13,9 +13,9 @@ CREATE TABLE vibetype.address (
   region      TEXT CHECK (char_length(region) > 0 AND char_length(region) <= 300),
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by  UUID REFERENCES vibetype.account(id) NOT NULL,
+  created_by  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   updated_at  TIMESTAMP WITH TIME ZONE,
-  updated_by  UUID REFERENCES vibetype.account(id)
+  updated_by  UUID REFERENCES vibetype.account(id) ON DELETE SET NULL
 );
 
 CREATE INDEX idx_address_location ON vibetype.address USING gist (location);

--- a/src/deploy/table_contact.sql
+++ b/src/deploy/table_contact.sql
@@ -4,7 +4,7 @@ CREATE TABLE vibetype.contact (
   id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
   account_id            UUID REFERENCES vibetype.account(id) ON DELETE SET NULL,
-  address_id            UUID REFERENCES vibetype.address(id)  ON DELETE SET NULL,
+  address_id            UUID REFERENCES vibetype.address(id) ON DELETE SET NULL,
   email_address         TEXT CHECK (char_length(email_address) < 255), -- no regex check as "a valid email address is one that you can send emails to" (http://www.dominicsayers.com/isemail/)
   email_address_hash    TEXT GENERATED ALWAYS AS (md5(lower(substring(email_address, '\S(?:.*\S)*')))) STORED, -- for gravatar profile pictures
   first_name            TEXT CHECK (char_length(first_name) > 0 AND char_length(first_name) <= 100),

--- a/src/deploy/table_contact.sql
+++ b/src/deploy/table_contact.sql
@@ -3,8 +3,8 @@ BEGIN;
 CREATE TABLE vibetype.contact (
   id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  account_id            UUID REFERENCES vibetype.account(id),
-  address_id            UUID REFERENCES vibetype.address(id),
+  account_id            UUID REFERENCES vibetype.account(id) ON DELETE SET NULL,
+  address_id            UUID REFERENCES vibetype.address(id)  ON DELETE SET NULL,
   email_address         TEXT CHECK (char_length(email_address) < 255), -- no regex check as "a valid email address is one that you can send emails to" (http://www.dominicsayers.com/isemail/)
   email_address_hash    TEXT GENERATED ALWAYS AS (md5(lower(substring(email_address, '\S(?:.*\S)*')))) STORED, -- for gravatar profile pictures
   first_name            TEXT CHECK (char_length(first_name) > 0 AND char_length(first_name) <= 100),

--- a/src/deploy/table_device.sql
+++ b/src/deploy/table_device.sql
@@ -6,9 +6,9 @@ CREATE TABLE vibetype.device (
   fcm_token   TEXT CHECK (char_length("fcm_token") > 0 AND char_length("fcm_token") < 300),
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by  UUID REFERENCES vibetype.account(id) NOT NULL,
+  created_by  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   updated_at  TIMESTAMP WITH TIME ZONE,
-  updated_by  UUID REFERENCES vibetype.account(id),
+  updated_by  UUID REFERENCES vibetype.account(id) ON DELETE SET NULL,
 
   UNIQUE (created_by, fcm_token)
 );

--- a/src/deploy/table_event.sql
+++ b/src/deploy/table_event.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE TABLE vibetype.event (
   id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  address_id               UUID REFERENCES vibetype.address(id),
+  address_id               UUID REFERENCES vibetype.address(id) ON DELETE SET NULL,
   description              TEXT CHECK (char_length("description") > 0 AND char_length("description") < 1000000),
   "end"                    TIMESTAMP WITH TIME ZONE,
   guest_count_maximum    INTEGER CHECK (guest_count_maximum > 0),

--- a/src/deploy/table_event.sql
+++ b/src/deploy/table_event.sql
@@ -18,7 +18,7 @@ CREATE TABLE vibetype.event (
   visibility               vibetype.event_visibility NOT NULL,
 
   created_at               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by               UUID NOT NULL REFERENCES vibetype.account(id),
+  created_by               UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   search_vector            TSVECTOR,
 
   UNIQUE (created_by, slug)

--- a/src/deploy/table_event_favorite.sql
+++ b/src/deploy/table_event_favorite.sql
@@ -3,10 +3,10 @@ BEGIN;
 CREATE TABLE vibetype.event_favorite (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  event_id    UUID REFERENCES vibetype.event(id),
+  event_id    UUID REFERENCES vibetype.event(id) ON DELETE CASCADE,
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by  UUID REFERENCES vibetype.account(id) NOT NULL,
+  created_by  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   UNIQUE (created_by, event_id)
 );

--- a/src/deploy/table_event_group.sql
+++ b/src/deploy/table_event_group.sql
@@ -9,7 +9,7 @@ CREATE TABLE vibetype.event_group (
   slug                  TEXT NOT NULL CHECK (char_length(slug) < 100 AND slug ~ '^[-A-Za-z0-9]+$'),
 
   created_at            TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by            UUID NOT NULL REFERENCES vibetype.account(id),
+  created_by            UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   UNIQUE (created_by, slug)
 );

--- a/src/deploy/table_event_grouping.sql
+++ b/src/deploy/table_event_grouping.sql
@@ -3,8 +3,8 @@ BEGIN;
 CREATE TABLE vibetype.event_grouping (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  event_group_id    UUID NOT NULL REFERENCES vibetype.event_group(id),
-  event_id          UUID NOT NULL REFERENCES vibetype.event(id),
+  event_group_id    UUID NOT NULL REFERENCES vibetype.event_group(id) ON DELETE CASCADE,
+  event_id          UUID NOT NULL REFERENCES vibetype.event(id) ON DELETE CASCADE,
 
   UNIQUE (event_id, event_group_id)
 );

--- a/src/deploy/table_event_upload.sql
+++ b/src/deploy/table_event_upload.sql
@@ -3,9 +3,9 @@ BEGIN;
 CREATE TABLE vibetype.event_upload (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  event_id          UUID NOT NULL REFERENCES vibetype.event(id),
+  event_id          UUID NOT NULL REFERENCES vibetype.event(id) ON DELETE CASCADE,
   is_header_image   BOOLEAN,
-  upload_id         UUID NOT NULL REFERENCES vibetype.upload(id),
+  upload_id         UUID NOT NULL REFERENCES vibetype.upload(id) ON DELETE CASCADE,
 
   UNIQUE (event_id, upload_id)
 );

--- a/src/deploy/table_friendship.sql
+++ b/src/deploy/table_friendship.sql
@@ -10,7 +10,7 @@ CREATE TABLE vibetype.friendship (
   created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   created_by          UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   updated_at          TIMESTAMP WITH TIME ZONE,
-  updated_by          UUID REFERENCES vibetype.account(id) ON DELETE CASCADE,
+  updated_by          UUID REFERENCES vibetype.account(id) ON DELETE SET NULL,
 
   UNIQUE (a_account_id, b_account_id),
   CONSTRAINT friendship_creator_participant CHECK (created_by = a_account_id or created_by = b_account_id),

--- a/src/deploy/table_friendship.sql
+++ b/src/deploy/table_friendship.sql
@@ -3,14 +3,14 @@ BEGIN;
 CREATE TABLE vibetype.friendship (
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  a_account_id        UUID NOT NULL REFERENCES vibetype.account(id),
-  b_account_id        UUID NOT NULL REFERENCES vibetype.account(id),
+  a_account_id        UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
+  b_account_id        UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   status              vibetype.friendship_status NOT NULL DEFAULT 'requested'::vibetype.friendship_status,
 
   created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by          UUID NOT NULL REFERENCES vibetype.account(id),
+  created_by          UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   updated_at          TIMESTAMP WITH TIME ZONE,
-  updated_by          UUID REFERENCES vibetype.account(id),
+  updated_by          UUID REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   UNIQUE (a_account_id, b_account_id),
   CONSTRAINT friendship_creator_participant CHECK (created_by = a_account_id or created_by = b_account_id),

--- a/src/deploy/table_guest.sql
+++ b/src/deploy/table_guest.sql
@@ -3,14 +3,14 @@ BEGIN;
 CREATE TABLE vibetype.guest (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  contact_id        UUID NOT NULL REFERENCES vibetype.contact(id),
-  event_id          UUID NOT NULL REFERENCES vibetype.event(id),
+  contact_id        UUID NOT NULL REFERENCES vibetype.contact(id) ON DELETE CASCADE,
+  event_id          UUID NOT NULL REFERENCES vibetype.event(id) ON DELETE CASCADE,
   feedback          vibetype.invitation_feedback,
   feedback_paper    vibetype.invitation_feedback_paper,
 
   created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at        TIMESTAMP WITH TIME ZONE,
-  updated_by        UUID REFERENCES vibetype.account(id),
+  updated_by        UUID REFERENCES vibetype.account(id) ON DELETE SET NULL,
 
   UNIQUE (event_id, contact_id)
 );

--- a/src/deploy/table_profile_picture.sql
+++ b/src/deploy/table_profile_picture.sql
@@ -5,8 +5,10 @@ BEGIN;
 CREATE TABLE vibetype.profile_picture (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  account_id    UUID NOT NULL REFERENCES vibetype.account(id) UNIQUE,
-  upload_id     UUID NOT NULL REFERENCES vibetype.upload(id)
+  account_id    UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
+  upload_id     UUID NOT NULL REFERENCES vibetype.upload(id) ON DELETE CASCADE,
+
+  CONSTRAINT profile_picture_unique UNIQUE (account_id)
 );
 
 COMMENT ON TABLE vibetype.profile_picture IS 'Mapping of account ids to upload ids.';

--- a/src/deploy/table_report.sql
+++ b/src/deploy/table_report.sql
@@ -4,12 +4,12 @@ CREATE TABLE vibetype.report (
   id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
   reason              TEXT NOT NULL CHECK (char_length("reason") > 0 AND char_length("reason") < 2000),
-  target_account_id   UUID REFERENCES vibetype.account(id),
-  target_event_id     UUID REFERENCES vibetype.event(id),
-  target_upload_id    UUID REFERENCES vibetype.upload(id),
+  target_account_id   UUID REFERENCES vibetype.account(id) ON DELETE CASCADE,
+  target_event_id     UUID REFERENCES vibetype.event(id) ON DELETE CASCADE,
+  target_upload_id    UUID REFERENCES vibetype.upload(id) ON DELETE CASCADE,
 
   created_at          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by          UUID NOT NULL REFERENCES vibetype.account(id),
+  created_by          UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
 
   CHECK (num_nonnulls(target_account_id, target_event_id, target_upload_id) = 1),
   UNIQUE (created_by, target_account_id, target_event_id, target_upload_id)

--- a/src/deploy/table_upload.sql
+++ b/src/deploy/table_upload.sql
@@ -3,7 +3,7 @@ BEGIN;
 CREATE TABLE vibetype.upload (
   id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
-  account_id     UUID NOT NULL REFERENCES vibetype.account(id),
+  account_id     UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   name           TEXT CHECK (char_length("name") > 0 AND char_length("name") < 300),
   size_byte      BIGINT NOT NULL CHECK (size_byte > 0),
   storage_key    TEXT UNIQUE,

--- a/src/verify/test_postgres.sql
+++ b/src/verify/test_postgres.sql
@@ -2,8 +2,8 @@ BEGIN;
 
 CREATE TABLE vibetype_test.base (id UUID PRIMARY KEY, text TEXT);
 CREATE INDEX idx_base_text ON vibetype_test.base USING btree (text);
-CREATE TABLE vibetype.depentent (base_id UUID REFERENCES vibetype_test.base(id));
-CREATE INDEX idx_dependent_base_id ON vibetype.depentent USING btree (base_id);
+CREATE TABLE vibetype.dependent (base_id UUID REFERENCES vibetype_test.base(id) ON DELETE CASCADE);
+CREATE INDEX idx_dependent_base_id ON vibetype.dependent USING btree (base_id);
 
 SAVEPOINT schema_implicit;
 DO $$
@@ -115,7 +115,7 @@ END $$;
 ROLLBACK TO SAVEPOINT schema_implicit_multiple_failure;
 
 DROP INDEX vibetype.idx_dependent_base_id;
-DROP TABLE vibetype.depentent;
+DROP TABLE vibetype.dependent;
 DROP INDEX vibetype_test.idx_base_text;
 DROP TABLE vibetype_test.base;
 

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -6192,7 +6192,7 @@ ALTER TABLE ONLY vibetype.friendship
 --
 
 ALTER TABLE ONLY vibetype.friendship
-    ADD CONSTRAINT friendship_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
+    ADD CONSTRAINT friendship_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE SET NULL;
 
 
 --

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -6064,7 +6064,7 @@ ALTER TABLE ONLY vibetype.device
 --
 
 ALTER TABLE ONLY vibetype.event
-    ADD CONSTRAINT event_address_id_fkey FOREIGN KEY (address_id) REFERENCES vibetype.address(id);
+    ADD CONSTRAINT event_address_id_fkey FOREIGN KEY (address_id) REFERENCES vibetype.address(id) ON DELETE SET NULL;
 
 
 --

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -5564,19 +5564,19 @@ ALTER TABLE ONLY vibetype.legal_term
 
 
 --
--- Name: profile_picture profile_picture_account_id_key; Type: CONSTRAINT; Schema: vibetype; Owner: ci
---
-
-ALTER TABLE ONLY vibetype.profile_picture
-    ADD CONSTRAINT profile_picture_account_id_key UNIQUE (account_id);
-
-
---
 -- Name: profile_picture profile_picture_pkey; Type: CONSTRAINT; Schema: vibetype; Owner: ci
 --
 
 ALTER TABLE ONLY vibetype.profile_picture
     ADD CONSTRAINT profile_picture_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: profile_picture profile_picture_unique; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.profile_picture
+    ADD CONSTRAINT profile_picture_unique UNIQUE (account_id);
 
 
 --
@@ -5944,7 +5944,7 @@ ALTER TABLE ONLY sqitch.tags
 --
 
 ALTER TABLE ONLY vibetype.account_block
-    ADD CONSTRAINT account_block_blocked_account_id_fkey FOREIGN KEY (blocked_account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT account_block_blocked_account_id_fkey FOREIGN KEY (blocked_account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -5952,7 +5952,7 @@ ALTER TABLE ONLY vibetype.account_block
 --
 
 ALTER TABLE ONLY vibetype.account_block
-    ADD CONSTRAINT account_block_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT account_block_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -5984,7 +5984,7 @@ ALTER TABLE ONLY vibetype.account_interest
 --
 
 ALTER TABLE ONLY vibetype.account_preference_event_size
-    ADD CONSTRAINT account_preference_event_size_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT account_preference_event_size_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6000,7 +6000,7 @@ ALTER TABLE ONLY vibetype.account_social_network
 --
 
 ALTER TABLE ONLY vibetype.achievement
-    ADD CONSTRAINT achievement_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT achievement_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6008,7 +6008,7 @@ ALTER TABLE ONLY vibetype.achievement
 --
 
 ALTER TABLE ONLY vibetype.address
-    ADD CONSTRAINT address_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT address_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6016,7 +6016,7 @@ ALTER TABLE ONLY vibetype.address
 --
 
 ALTER TABLE ONLY vibetype.address
-    ADD CONSTRAINT address_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT address_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE SET NULL;
 
 
 --
@@ -6024,7 +6024,7 @@ ALTER TABLE ONLY vibetype.address
 --
 
 ALTER TABLE ONLY vibetype.contact
-    ADD CONSTRAINT contact_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT contact_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id) ON DELETE SET NULL;
 
 
 --
@@ -6032,7 +6032,7 @@ ALTER TABLE ONLY vibetype.contact
 --
 
 ALTER TABLE ONLY vibetype.contact
-    ADD CONSTRAINT contact_address_id_fkey FOREIGN KEY (address_id) REFERENCES vibetype.address(id);
+    ADD CONSTRAINT contact_address_id_fkey FOREIGN KEY (address_id) REFERENCES vibetype.address(id) ON DELETE SET NULL;
 
 
 --
@@ -6048,7 +6048,7 @@ ALTER TABLE ONLY vibetype.contact
 --
 
 ALTER TABLE ONLY vibetype.device
-    ADD CONSTRAINT device_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT device_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6056,7 +6056,7 @@ ALTER TABLE ONLY vibetype.device
 --
 
 ALTER TABLE ONLY vibetype.device
-    ADD CONSTRAINT device_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT device_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE SET NULL;
 
 
 --
@@ -6088,7 +6088,7 @@ ALTER TABLE ONLY vibetype.event_category_mapping
 --
 
 ALTER TABLE ONLY vibetype.event
-    ADD CONSTRAINT event_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT event_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6096,7 +6096,7 @@ ALTER TABLE ONLY vibetype.event
 --
 
 ALTER TABLE ONLY vibetype.event_favorite
-    ADD CONSTRAINT event_favorite_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT event_favorite_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6104,7 +6104,7 @@ ALTER TABLE ONLY vibetype.event_favorite
 --
 
 ALTER TABLE ONLY vibetype.event_favorite
-    ADD CONSTRAINT event_favorite_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id);
+    ADD CONSTRAINT event_favorite_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
 
 
 --
@@ -6112,7 +6112,7 @@ ALTER TABLE ONLY vibetype.event_favorite
 --
 
 ALTER TABLE ONLY vibetype.event_group
-    ADD CONSTRAINT event_group_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT event_group_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6120,7 +6120,7 @@ ALTER TABLE ONLY vibetype.event_group
 --
 
 ALTER TABLE ONLY vibetype.event_grouping
-    ADD CONSTRAINT event_grouping_event_group_id_fkey FOREIGN KEY (event_group_id) REFERENCES vibetype.event_group(id);
+    ADD CONSTRAINT event_grouping_event_group_id_fkey FOREIGN KEY (event_group_id) REFERENCES vibetype.event_group(id) ON DELETE CASCADE;
 
 
 --
@@ -6128,7 +6128,7 @@ ALTER TABLE ONLY vibetype.event_grouping
 --
 
 ALTER TABLE ONLY vibetype.event_grouping
-    ADD CONSTRAINT event_grouping_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id);
+    ADD CONSTRAINT event_grouping_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
 
 
 --
@@ -6152,7 +6152,7 @@ ALTER TABLE ONLY vibetype.event_recommendation
 --
 
 ALTER TABLE ONLY vibetype.event_upload
-    ADD CONSTRAINT event_upload_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id);
+    ADD CONSTRAINT event_upload_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
 
 
 --
@@ -6160,7 +6160,7 @@ ALTER TABLE ONLY vibetype.event_upload
 --
 
 ALTER TABLE ONLY vibetype.event_upload
-    ADD CONSTRAINT event_upload_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES vibetype.upload(id);
+    ADD CONSTRAINT event_upload_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES vibetype.upload(id) ON DELETE CASCADE;
 
 
 --
@@ -6168,7 +6168,7 @@ ALTER TABLE ONLY vibetype.event_upload
 --
 
 ALTER TABLE ONLY vibetype.friendship
-    ADD CONSTRAINT friendship_a_account_id_fkey FOREIGN KEY (a_account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT friendship_a_account_id_fkey FOREIGN KEY (a_account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6176,7 +6176,7 @@ ALTER TABLE ONLY vibetype.friendship
 --
 
 ALTER TABLE ONLY vibetype.friendship
-    ADD CONSTRAINT friendship_b_account_id_fkey FOREIGN KEY (b_account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT friendship_b_account_id_fkey FOREIGN KEY (b_account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6184,7 +6184,7 @@ ALTER TABLE ONLY vibetype.friendship
 --
 
 ALTER TABLE ONLY vibetype.friendship
-    ADD CONSTRAINT friendship_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT friendship_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6192,7 +6192,7 @@ ALTER TABLE ONLY vibetype.friendship
 --
 
 ALTER TABLE ONLY vibetype.friendship
-    ADD CONSTRAINT friendship_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT friendship_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6200,7 +6200,7 @@ ALTER TABLE ONLY vibetype.friendship
 --
 
 ALTER TABLE ONLY vibetype.guest
-    ADD CONSTRAINT guest_contact_id_fkey FOREIGN KEY (contact_id) REFERENCES vibetype.contact(id);
+    ADD CONSTRAINT guest_contact_id_fkey FOREIGN KEY (contact_id) REFERENCES vibetype.contact(id) ON DELETE CASCADE;
 
 
 --
@@ -6208,7 +6208,7 @@ ALTER TABLE ONLY vibetype.guest
 --
 
 ALTER TABLE ONLY vibetype.guest
-    ADD CONSTRAINT guest_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id);
+    ADD CONSTRAINT guest_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
 
 
 --
@@ -6216,7 +6216,7 @@ ALTER TABLE ONLY vibetype.guest
 --
 
 ALTER TABLE ONLY vibetype.guest
-    ADD CONSTRAINT guest_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT guest_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES vibetype.account(id) ON DELETE SET NULL;
 
 
 --
@@ -6240,7 +6240,7 @@ ALTER TABLE ONLY vibetype.legal_term_acceptance
 --
 
 ALTER TABLE ONLY vibetype.profile_picture
-    ADD CONSTRAINT profile_picture_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT profile_picture_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6248,7 +6248,7 @@ ALTER TABLE ONLY vibetype.profile_picture
 --
 
 ALTER TABLE ONLY vibetype.profile_picture
-    ADD CONSTRAINT profile_picture_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES vibetype.upload(id);
+    ADD CONSTRAINT profile_picture_upload_id_fkey FOREIGN KEY (upload_id) REFERENCES vibetype.upload(id) ON DELETE CASCADE;
 
 
 --
@@ -6256,7 +6256,7 @@ ALTER TABLE ONLY vibetype.profile_picture
 --
 
 ALTER TABLE ONLY vibetype.report
-    ADD CONSTRAINT report_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT report_created_by_fkey FOREIGN KEY (created_by) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6264,7 +6264,7 @@ ALTER TABLE ONLY vibetype.report
 --
 
 ALTER TABLE ONLY vibetype.report
-    ADD CONSTRAINT report_target_account_id_fkey FOREIGN KEY (target_account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT report_target_account_id_fkey FOREIGN KEY (target_account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --
@@ -6272,7 +6272,7 @@ ALTER TABLE ONLY vibetype.report
 --
 
 ALTER TABLE ONLY vibetype.report
-    ADD CONSTRAINT report_target_event_id_fkey FOREIGN KEY (target_event_id) REFERENCES vibetype.event(id);
+    ADD CONSTRAINT report_target_event_id_fkey FOREIGN KEY (target_event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
 
 
 --
@@ -6280,7 +6280,7 @@ ALTER TABLE ONLY vibetype.report
 --
 
 ALTER TABLE ONLY vibetype.report
-    ADD CONSTRAINT report_target_upload_id_fkey FOREIGN KEY (target_upload_id) REFERENCES vibetype.upload(id);
+    ADD CONSTRAINT report_target_upload_id_fkey FOREIGN KEY (target_upload_id) REFERENCES vibetype.upload(id) ON DELETE CASCADE;
 
 
 --
@@ -6288,7 +6288,7 @@ ALTER TABLE ONLY vibetype.report
 --
 
 ALTER TABLE ONLY vibetype.upload
-    ADD CONSTRAINT upload_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id);
+    ADD CONSTRAINT upload_account_id_fkey FOREIGN KEY (account_id) REFERENCES vibetype.account(id) ON DELETE CASCADE;
 
 
 --


### PR DESCRIPTION
Many foreign key constrains did not have an `ON DELETE referential_action`clause. In many cases `ON DELETE CASCADE` was added, in a few cases `ON DELETE SET NULL`.

Waiting for:
- https://github.com/maevsi/sqitch/pull/168