### PR TITLE
feat(event): add format mapping

### DIFF
--- a/src/deploy/table_event_format.sql
+++ b/src/deploy/table_event_format.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE vibetype.event_format(
+  id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name  TEXT
+);
+
+COMMENT ON TABLE vibetype.event_format IS 'Event formats.';
+COMMENT ON COLUMN vibetype.event_format.id IS 'The id of the event format.';
+COMMENT ON COLUMN vibetype.event_format.name IS 'The name of the event format.';
+
+GRANT SELECT ON TABLE vibetype.event_format TO vibetype_anonymous, vibetype_account;
+
+-- no row level security necessary for this table as it does not contain user data
+
+END;

--- a/src/deploy/table_event_format_mapping.sql
+++ b/src/deploy/table_event_format_mapping.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+CREATE TABLE vibetype.event_format_mapping (
+  event_id  UUID NOT NULL REFERENCES vibetype.event(id) ON DELETE CASCADE,
+  format_id UUID NOT NULL REFERENCES vibetype.event_format(id) ON DELETE CASCADE,
+
+  PRIMARY KEY (event_id, format_id)
+);
+
+COMMENT ON TABLE vibetype.event_format_mapping IS 'Mapping events to formats (M:N relationship).';
+COMMENT ON COLUMN vibetype.event_format_mapping.event_id IS 'An event id.';
+COMMENT ON COLUMN vibetype.event_format_mapping.format_id IS 'A format id.';
+
+GRANT SELECT ON TABLE vibetype.event_format_mapping TO vibetype_anonymous;
+GRANT SELECT, INSERT, DELETE ON TABLE vibetype.event_format_mapping TO vibetype_account;
+
+ALTER TABLE vibetype.event_format_mapping ENABLE ROW LEVEL SECURITY;
+
+-- Only allow selects for accessible events.
+CREATE POLICY event_format_mapping_select ON vibetype.event_format_mapping FOR SELECT USING (
+  event_id IN (SELECT id FROM vibetype.event)
+);
+
+-- Only allow inserts for events created by user.
+CREATE POLICY event_format_mapping_insert ON vibetype.event_format_mapping FOR INSERT WITH CHECK (
+  (SELECT created_by FROM vibetype.event WHERE id = event_id) = vibetype.invoker_account_id()
+);
+
+-- Only allow deletes for events created by user.
+CREATE POLICY event_format_mapping_delete ON vibetype.event_format_mapping FOR DELETE USING (
+  (SELECT created_by FROM vibetype.event WHERE id = event_id) = vibetype.invoker_account_id()
+);
+
+COMMIT;

--- a/src/revert/table_event_format.sql
+++ b/src/revert/table_event_format.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE vibetype.event_format;
+
+COMMIT;

--- a/src/revert/table_event_format_mapping.sql
+++ b/src/revert/table_event_format_mapping.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP POLICY event_format_mapping_delete ON vibetype.event_format_mapping;
+DROP POLICY event_format_mapping_insert ON vibetype.event_format_mapping;
+DROP POLICY event_format_mapping_select ON vibetype.event_format_mapping;
+
+DROP TABLE vibetype.event_format_mapping;
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -101,3 +101,5 @@ enum_friendship_status [schema_public] 1970-01-01T00:00:00Z Sven Thelemann <sven
 table_friendship [schema_public enum_friendship_status table_account_public function_trigger_metadata_update] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # A friend relation together with its status.
 table_friendship_policy [schema_public table_friendship role_account] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Policy for table friend.
 test_friendship [schema_test] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Test cases for friendship.
+table_event_format [schema_public role_anonymous role_account] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Table for storing event formats.
+table_event_format_mapping [schema_public table_event table_event_format role_anonymous role_account function_invoker_account_id] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Table for storing event to category (M:N) relationships.

--- a/src/verify/table_event_format.sql
+++ b/src/verify/table_event_format.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+SET local role.vibetype_username TO :'role_vibetype_username';
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format', 'UPDATE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format', 'DELETE'));
+END $$;
+
+SELECT
+  id,
+  name
+FROM vibetype.event_format WHERE FALSE;
+
+ROLLBACK;

--- a/src/verify/table_event_format_mapping.sql
+++ b/src/verify/table_event_format_mapping.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+\set role_vibetype_username `cat /run/secrets/postgres_role_vibetype_username`
+SET local role.vibetype_username TO :'role_vibetype_username';
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format_mapping', 'SELECT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format_mapping', 'INSERT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format_mapping', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_format_mapping', 'UPDATE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format_mapping', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format_mapping', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format_mapping', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_format_mapping', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format_mapping', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format_mapping', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format_mapping', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_format_mapping', 'DELETE'));
+END $$;
+
+SELECT event_id,
+       format_id
+FROM vibetype.event_format_mapping WHERE FALSE;
+
+ROLLBACK;

--- a/test/schema/schema.definition.sql
+++ b/test/schema/schema.definition.sql
@@ -4336,6 +4336,72 @@ Reference to the account that created the event favorite.';
 
 
 --
+-- Name: event_format; Type: TABLE; Schema: vibetype; Owner: ci
+--
+
+CREATE TABLE vibetype.event_format (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name text
+);
+
+
+ALTER TABLE vibetype.event_format OWNER TO ci;
+
+--
+-- Name: TABLE event_format; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON TABLE vibetype.event_format IS 'Event formats.';
+
+
+--
+-- Name: COLUMN event_format.id; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON COLUMN vibetype.event_format.id IS 'The id of the event format.';
+
+
+--
+-- Name: COLUMN event_format.name; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON COLUMN vibetype.event_format.name IS 'The name of the event format.';
+
+
+--
+-- Name: event_format_mapping; Type: TABLE; Schema: vibetype; Owner: ci
+--
+
+CREATE TABLE vibetype.event_format_mapping (
+    event_id uuid NOT NULL,
+    format_id uuid NOT NULL
+);
+
+
+ALTER TABLE vibetype.event_format_mapping OWNER TO ci;
+
+--
+-- Name: TABLE event_format_mapping; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON TABLE vibetype.event_format_mapping IS 'Mapping events to formats (M:N relationship).';
+
+
+--
+-- Name: COLUMN event_format_mapping.event_id; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON COLUMN vibetype.event_format_mapping.event_id IS 'An event id.';
+
+
+--
+-- Name: COLUMN event_format_mapping.format_id; Type: COMMENT; Schema: vibetype; Owner: ci
+--
+
+COMMENT ON COLUMN vibetype.event_format_mapping.format_id IS 'A format id.';
+
+
+--
 -- Name: event_group; Type: TABLE; Schema: vibetype; Owner: ci
 --
 
@@ -5437,6 +5503,22 @@ ALTER TABLE ONLY vibetype.event_favorite
 
 
 --
+-- Name: event_format_mapping event_format_mapping_pkey; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.event_format_mapping
+    ADD CONSTRAINT event_format_mapping_pkey PRIMARY KEY (event_id, format_id);
+
+
+--
+-- Name: event_format event_format_pkey; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.event_format
+    ADD CONSTRAINT event_format_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: event_group event_group_created_by_slug_key; Type: CONSTRAINT; Schema: vibetype; Owner: ci
 --
 
@@ -6108,6 +6190,22 @@ ALTER TABLE ONLY vibetype.event_favorite
 
 
 --
+-- Name: event_format_mapping event_format_mapping_event_id_fkey; Type: FK CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.event_format_mapping
+    ADD CONSTRAINT event_format_mapping_event_id_fkey FOREIGN KEY (event_id) REFERENCES vibetype.event(id) ON DELETE CASCADE;
+
+
+--
+-- Name: event_format_mapping event_format_mapping_format_id_fkey; Type: FK CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.event_format_mapping
+    ADD CONSTRAINT event_format_mapping_format_id_fkey FOREIGN KEY (format_id) REFERENCES vibetype.event_format(id) ON DELETE CASCADE;
+
+
+--
 -- Name: event_group event_group_created_by_fkey; Type: FK CONSTRAINT; Schema: vibetype; Owner: ci
 --
 
@@ -6562,6 +6660,38 @@ CREATE POLICY event_favorite_insert ON vibetype.event_favorite FOR INSERT WITH C
 --
 
 CREATE POLICY event_favorite_select ON vibetype.event_favorite FOR SELECT USING ((created_by = vibetype.invoker_account_id()));
+
+
+--
+-- Name: event_format_mapping; Type: ROW SECURITY; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE vibetype.event_format_mapping ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: event_format_mapping event_format_mapping_delete; Type: POLICY; Schema: vibetype; Owner: ci
+--
+
+CREATE POLICY event_format_mapping_delete ON vibetype.event_format_mapping FOR DELETE USING ((( SELECT event.created_by
+   FROM vibetype.event
+  WHERE (event.id = event_format_mapping.event_id)) = vibetype.invoker_account_id()));
+
+
+--
+-- Name: event_format_mapping event_format_mapping_insert; Type: POLICY; Schema: vibetype; Owner: ci
+--
+
+CREATE POLICY event_format_mapping_insert ON vibetype.event_format_mapping FOR INSERT WITH CHECK ((( SELECT event.created_by
+   FROM vibetype.event
+  WHERE (event.id = event_format_mapping.event_id)) = vibetype.invoker_account_id()));
+
+
+--
+-- Name: event_format_mapping event_format_mapping_select; Type: POLICY; Schema: vibetype; Owner: ci
+--
+
+CREATE POLICY event_format_mapping_select ON vibetype.event_format_mapping FOR SELECT USING ((event_id IN ( SELECT event.id
+   FROM vibetype.event)));
 
 
 --
@@ -7810,6 +7940,22 @@ GRANT SELECT,INSERT,DELETE ON TABLE vibetype.event_category_mapping TO vibetype_
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE vibetype.event_favorite TO vibetype_account;
+
+
+--
+-- Name: TABLE event_format; Type: ACL; Schema: vibetype; Owner: ci
+--
+
+GRANT SELECT ON TABLE vibetype.event_format TO vibetype_anonymous;
+GRANT SELECT ON TABLE vibetype.event_format TO vibetype_account;
+
+
+--
+-- Name: TABLE event_format_mapping; Type: ACL; Schema: vibetype; Owner: ci
+--
+
+GRANT SELECT ON TABLE vibetype.event_format_mapping TO vibetype_anonymous;
+GRANT SELECT,INSERT,DELETE ON TABLE vibetype.event_format_mapping TO vibetype_account;
 
 
 --


### PR DESCRIPTION
In addition to an event category (like "arts") there should be an event format (like "lecture"). This PR adds the required mapping.

TODO: extend the `account_interest` concept so that accounts can show their interests in event formats as well. @sthelemann could you take this over? I'd propose to rename `account_interest` to `account_preference_event_category` (as we already have `account_preference_event_size` following this naming scheme) and create a new `account_preference_event_format` in a separate PR basing off of `beta`.