### PR TITLE
feat(account)!: fail silently at registration on duplicate email

### DIFF
--- a/src/deploy/function_account_email_address_verification.sql
+++ b/src/deploy/function_account_email_address_verification.sql
@@ -40,11 +40,15 @@ DECLARE
   _verification UUID;
 BEGIN
   _legal_term_id := vibetype_test.legal_term_singleton();
-  _account_id := vibetype.account_registration(_email_address, 'en', _legal_term_id, 'password', _username);
+  PERFORM vibetype.account_registration(_email_address, 'en', _legal_term_id, 'password', _username);
+
+  SELECT id INTO _account_id
+    FROM vibetype.account
+    WHERE username = _username;
 
   SELECT email_address_verification INTO _verification
-  FROM vibetype_private.account
-  WHERE id = _account_id;
+    FROM vibetype_private.account
+    WHERE id = _account_id;
 
   PERFORM vibetype.account_email_address_verification(_verification);
 

--- a/src/deploy/function_account_registration.sql
+++ b/src/deploy/function_account_registration.sql
@@ -6,7 +6,7 @@ CREATE FUNCTION vibetype.account_registration(
   legal_term_id UUID,
   password TEXT,
   username TEXT
-) RETURNS UUID AS $$
+) RETURNS VOID AS $$
 DECLARE
   _new_account_private vibetype_private.account;
   _new_account_public vibetype.account;
@@ -21,7 +21,7 @@ BEGIN
   END IF;
 
   IF (EXISTS (SELECT 1 FROM vibetype_private.account WHERE account.email_address = account_registration.email_address)) THEN
-    RAISE 'An account with this email address already exists!' USING ERRCODE = 'unique_violation';
+    RETURN; -- silent fail as we cannot return meta information about users' email addresses
   END IF;
 
   INSERT INTO vibetype_private.account(email_address, password_hash, last_activity) VALUES
@@ -51,8 +51,6 @@ BEGIN
       'template', jsonb_build_object('language', account_registration.language)
     ))
   );
-
-  RETURN _new_account_public.id;
 END;
 $$ LANGUAGE PLPGSQL STRICT SECURITY DEFINER;
 

--- a/src/verify/function_account_registration.sql
+++ b/src/verify/function_account_registration.sql
@@ -58,9 +58,6 @@ BEGIN
   _legal_term_id := vibetype_test.legal_term_singleton();
   PERFORM vibetype.account_registration('duplicate@example.com', 'en', _legal_term_id, 'password', 'username-diff');
   PERFORM vibetype.account_registration('duplicate@example.com', 'en', _legal_term_id, 'password', 'username-erent');
-  RAISE EXCEPTION 'Test failed: Duplicate email not enforced';
-EXCEPTION WHEN unique_violation THEN
-  NULL;
 END $$;
 ROLLBACK TO SAVEPOINT email_uniqueness;
 


### PR DESCRIPTION
We can't tell about the existence of email addresses within our system.

cc @sthelemann 