### PR TITLE
docs(project): simplify scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Once your development environment is running, use these commands to manage datab
 ```bash
 npx nypm install      # initial set up & update installation
 
-npx nypm run deploy   # apply database migrations
-npx nypm run revert   # roll back database migrations
+npm run deploy   # apply database migrations
+npm run revert   # roll back database migrations
 
-npx nypm run test     # execute test suite
+npm run test     # execute test suite
 ```
 
 After setup, you can inspect and test GraphQL queries and mutations using GraphiQL at https://postgraphile.localhost/graphiql.
 
-> 💡 Tip: You can run `npx nypm run sqitch <command> [options]` to access full Sqitch functionality.
+> 💡 Tip: You can run `npm run sqitch <command> [options]` to access full Sqitch functionality.
 
 <!-- TODO: Add a way to inspect the schema without launching the full maevsi/stack. -->
 

--- a/docs/onboarding/project.md
+++ b/docs/onboarding/project.md
@@ -6,7 +6,7 @@ Welcome! This guide provides a clear understanding of the `maevsi/sqitch` projec
 
 The `src` directory contains the Sqitch executable, which you can use to interact with the migrations located in the directory's subdirectories.
 The executable is a shell script that invokes Sqitch's Docker image.
-When you run `npx nypm run deploy` to deploy the database migrations, this package script invokes the Sqitch executable.
+When you run `npm run deploy` to deploy the database migrations, this package script invokes the Sqitch executable.
 
 The other files in `src` follow the structure outlined in the [Sqitch documentation](https://sqitch.org/docs/).
 
@@ -16,7 +16,7 @@ The other files in `src` follow the structure outlined in the [Sqitch documentat
 To run all Sqitch tests, execute:
 
 ```sh
-npx nypm run test
+npm run test
 ```
 
 This will:
@@ -52,7 +52,7 @@ git add -AN && git diff > test/data.patch
 Before submitting a pull request, update the schema artifact to ensure consistency by running:
 
 ```sh
-npx nypm run test:update
+npm run test:update
 ```
 
 Be sure to include any resulting changes in your pull request.

--- a/package.json
+++ b/package.json
@@ -12,14 +12,12 @@
   "packageManager": "pnpm@10.10.0",
   "private": true,
   "scripts": {
-    "deploy": "pnpm run sqitch:deploy",
+    "deploy": "npm run sqitch deploy",
     "prepare": "husky",
-    "revert": "pnpm run sqitch:revert",
+    "revert": "npm run sqitch revert",
     "sqitch": "./src/sqitch",
-    "sqitch:deploy": "pnpm run sqitch deploy",
-    "sqitch:revert": "pnpm run sqitch revert",
     "test": "./test/schema/schema-update.sh",
-    "test:update": "pnpm run test --update"
+    "test:update": "npm run test --update"
   },
   "type": "module",
   "version": "7.0.1"

--- a/src/sqitch
+++ b/src/sqitch
@@ -65,12 +65,22 @@ elif [ ! -t 0 ]; then
     passopt+=(--interactive)
 fi
 
+THIS=$(dirname "$(readlink -f "$0")")
+
+function docker_sudo() {
+    if id -nG | grep -qw "docker"; then
+        docker "$@"
+    else
+        sudo --preserve-env="SQITCH_TARGET" docker "$@"
+    fi
+}
+
 # Run the container with the current and home directories mounted.
-docker run --rm --network host \
-    --mount "type=bind,src=$(pwd),dst=/repo" \
+docker_sudo run --rm --network host \
+    --mount "type=bind,src=$THIS,dst=/repo" \
     --mount "type=bind,src=$HOME,dst=$homedst" \
-    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_service_vibetype_password.secret,dst=/run/secrets/postgres_role_service_vibetype_password" \
-    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_service_vibetype_username.secret,dst=/run/secrets/postgres_role_service_vibetype_username" \
-    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_service_postgraphile_password.secret,dst=/run/secrets/postgres_role_service_postgraphile_password" \
-    --mount "type=bind,src=$PWD/../../stack/src/development/secrets/postgres/role_service_postgraphile_username.secret,dst=/run/secrets/postgres_role_service_postgraphile_username" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_vibetype_password.secret,dst=/run/secrets/postgres_role_service_vibetype_password" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_vibetype_username.secret,dst=/run/secrets/postgres_role_service_vibetype_username" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_password.secret,dst=/run/secrets/postgres_role_service_postgraphile_password" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_username.secret,dst=/run/secrets/postgres_role_service_postgraphile_username" \
     "${passopt[@]}" "$SQITCH_IMAGE" "$@"


### PR DESCRIPTION
No need to use `nypm` in all cases. This PR also makes the sqitch script ask for a sudo password automatically now if required.