### PR TITLE
feat(grafana)!: readd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,12 @@ RUN apt-get update \
   && apt-get install --no-install-recommends -y \
     sqitch=1.1.0000-1 \
   && mkdir -p /run/secrets \
+  && echo "grafana" > /run/secrets/postgres_role_service_grafana_username \
   && echo "postgres"      > /run/secrets/postgres_password \
   && echo "postgraphile"  > /run/secrets/postgres_role_service_postgraphile_username \
   && echo "vibetype"          > /run/secrets/postgres_role_service_vibetype_username \
   && echo "placeholder" | tee \
+    /run/secrets/postgres_role_service_grafana_password \
     /run/secrets/postgres_role_service_postgraphile_password \
     /run/secrets/postgres_role_service_vibetype_password \
     /dev/null

--- a/src/deploy/database_grafana.sql
+++ b/src/deploy/database_grafana.sql
@@ -1,0 +1,8 @@
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
+SELECT 'CREATE DATABASE grafana OWNER "' || :'role_service_grafana_username' || '";'
+WHERE NOT EXISTS (
+  SELECT FROM pg_database WHERE datname = 'grafana'
+)\gexec
+
+COMMENT ON DATABASE grafana IS 'The observation dashboard''s database.';

--- a/src/deploy/role_grafana.sql
+++ b/src/deploy/role_grafana.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+\set role_service_grafana_password `cat /run/secrets/postgres_role_service_grafana_password`
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
+DROP ROLE IF EXISTS :role_service_grafana_username;
+CREATE ROLE :role_service_grafana_username LOGIN PASSWORD :'role_service_grafana_password';
+
+COMMIT;

--- a/src/deploy/schema_private.sql
+++ b/src/deploy/schema_private.sql
@@ -1,7 +1,11 @@
 BEGIN;
 
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
 CREATE SCHEMA vibetype_private;
 
 COMMENT ON SCHEMA vibetype_private IS 'Contains account information and is not used by PostGraphile.';
+
+GRANT USAGE ON SCHEMA vibetype_private TO :role_service_grafana_username;
 
 COMMIT;

--- a/src/deploy/table_account_private.sql
+++ b/src/deploy/table_account_private.sql
@@ -1,5 +1,7 @@
 BEGIN;
 
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
 CREATE TABLE vibetype_private.account (
   id                                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
@@ -85,5 +87,7 @@ CREATE TRIGGER vibetype_private_account_password_reset_verification_valid_until
   ON vibetype_private.account
   FOR EACH ROW
   EXECUTE PROCEDURE vibetype_private.account_password_reset_verification_valid_until();
+
+GRANT SELECT ON TABLE vibetype_private.account TO :role_service_grafana_username;
 
 COMMIT;

--- a/src/revert/database_grafana.sql
+++ b/src/revert/database_grafana.sql
@@ -1,0 +1,1 @@
+DROP DATABASE grafana WITH (FORCE);

--- a/src/revert/role_grafana.sql
+++ b/src/revert/role_grafana.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
+DROP ROLE :role_service_grafana_username;
+
+COMMIT;

--- a/src/sqitch
+++ b/src/sqitch
@@ -79,6 +79,8 @@ function docker_sudo() {
 docker_sudo run --rm --network host \
     --mount "type=bind,src=$THIS,dst=/repo" \
     --mount "type=bind,src=$HOME,dst=$homedst" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_grafana_password.secret,dst=/run/secrets/postgres_role_service_grafana_password" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_grafana_username.secret,dst=/run/secrets/postgres_role_service_grafana_username" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_password.secret,dst=/run/secrets/postgres_role_service_postgraphile_password" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_username.secret,dst=/run/secrets/postgres_role_service_postgraphile_username" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_vibetype_password.secret,dst=/run/secrets/postgres_role_service_vibetype_password" \

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -3,6 +3,8 @@
 %uri=https://github.com/maevsi/vibetype/
 
 privilege_execute_revoke 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Revoke execute privilege from public.
+role_grafana 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+maevsi/sqitch@jonas-thelemann.de> # Add role grafana.
+database_grafana [role_grafana] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+maevsi/sqitch@jonas-thelemann.de> # Add the database for grafana.
 role_postgraphile 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add role postgraphile.
 role_anonymous [role_postgraphile] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add role anonymous.
 role_account [role_postgraphile] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add role account.

--- a/src/verify/database_grafana.sql
+++ b/src/verify/database_grafana.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DO $$
+BEGIN
+  ASSERT (SELECT 1 FROM pg_database WHERE datname='grafana') = 1;
+END $$;
+
+ROLLBACK;

--- a/src/verify/role_grafana.sql
+++ b/src/verify/role_grafana.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+\set role_service_grafana_username `cat /run/secrets/postgres_role_service_grafana_username`
+
+SET LOCAL role.service_grafana_username TO :'role_service_grafana_username';
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.pg_has_role(current_setting('role.service_grafana_username'), 'USAGE'));
+  -- Other accounts might not exist yet for a NOT-check.
+END $$;
+
+ROLLBACK;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -6487,6 +6487,13 @@ GRANT USAGE ON SCHEMA vibetype TO vibetype;
 
 
 --
+-- Name: SCHEMA vibetype_private; Type: ACL; Schema: -; Owner: ci
+--
+
+GRANT USAGE ON SCHEMA vibetype_private TO grafana;
+
+
+--
 -- Name: FUNCTION armor(bytea); Type: ACL; Schema: public; Owner: ci
 --
 
@@ -7312,6 +7319,13 @@ GRANT SELECT,INSERT ON TABLE vibetype.report TO vibetype_account;
 GRANT SELECT ON TABLE vibetype.upload TO vibetype_anonymous;
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE vibetype.upload TO vibetype_account;
 GRANT SELECT,UPDATE ON TABLE vibetype.upload TO vibetype;
+
+
+--
+-- Name: TABLE account; Type: ACL; Schema: vibetype_private; Owner: ci
+--
+
+GRANT SELECT ON TABLE vibetype_private.account TO grafana;
 
 
 --


### PR DESCRIPTION
We had the Grafana integration here before but it has been removed due to some logical inaccuracies back then (https://github.com/maevsi/sqitch/pull/107). This PR readds the Grafana database and role so that it configures access permissions properly right away, meaning you can just start `maevsi/stack` and have working dashboard in the `grafana` service.

Test with https://github.com/maevsi/stack/pull/200 (which targets `beta` too).