### PR TITLE
chore!: specify function arguments for revert

### DIFF
--- a/src/revert/table_account_private.sql
+++ b/src/revert/table_account_private.sql
@@ -2,8 +2,8 @@ BEGIN;
 
 DROP TRIGGER vibetype_private_account_password_reset_verification_valid_until ON vibetype_private.account;
 DROP TRIGGER vibetype_private_account_email_address_verification_valid_until ON vibetype_private.account;
-DROP FUNCTION vibetype_private.account_password_reset_verification_valid_until;
-DROP FUNCTION vibetype_private.account_email_address_verification_valid_until;
+DROP FUNCTION vibetype_private.account_password_reset_verification_valid_until();
+DROP FUNCTION vibetype_private.account_email_address_verification_valid_until();
 DROP INDEX vibetype_private.idx_account_private_location;
 DROP TABLE vibetype_private.account;
 

--- a/src/revert/table_contact.sql
+++ b/src/revert/table_contact.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 DROP TRIGGER vibetype_trigger_contact_update_account_id ON vibetype.contact;
 
-DROP FUNCTION vibetype.trigger_contact_update_account_id;
+DROP FUNCTION vibetype.trigger_contact_update_account_id();
 
 DROP TABLE vibetype.contact;
 

--- a/src/revert/table_device.sql
+++ b/src/revert/table_device.sql
@@ -3,7 +3,7 @@ BEGIN;
 DROP POLICY device_all ON vibetype.device;
 
 DROP TRIGGER vibetype_trigger_device_update_fcm ON vibetype.device;
-DROP FUNCTION vibetype.trigger_metadata_update_fcm;
+DROP FUNCTION vibetype.trigger_metadata_update_fcm();
 DROP TRIGGER vibetype_trigger_device_update ON vibetype.device;
 
 DROP INDEX vibetype.idx_device_updated_by;

--- a/src/revert/table_event_policy.sql
+++ b/src/revert/table_event_policy.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 DROP POLICY event_select ON vibetype.event;
-DROP FUNCTION vibetype_private.event_policy_select;
+DROP FUNCTION vibetype_private.event_policy_select();
 DROP POLICY event_all ON vibetype.event;
 
 COMMIT;

--- a/src/revert/table_guest_policy.sql
+++ b/src/revert/table_guest_policy.sql
@@ -2,7 +2,7 @@ BEGIN;
 
 DROP TRIGGER vibetype_guest_update ON vibetype.guest;
 
-DROP FUNCTION vibetype.trigger_guest_update;
+DROP FUNCTION vibetype.trigger_guest_update();
 
 DROP POLICY guest_delete ON vibetype.guest;
 DROP POLICY guest_update ON vibetype.guest;

--- a/src/revert/table_legal_term.sql
+++ b/src/revert/table_legal_term.sql
@@ -4,7 +4,7 @@ DROP POLICY legal_term_select ON vibetype.legal_term;
 
 DROP TRIGGER vibetype_legal_term_delete ON vibetype.legal_term;
 DROP TRIGGER vibetype_legal_term_update ON vibetype.legal_term;
-DROP FUNCTION vibetype.legal_term_change;
+DROP FUNCTION vibetype.legal_term_change();
 
 DROP TABLE vibetype.legal_term;
 


### PR DESCRIPTION
Unifies the syntax for `DROP FUNCTION` statements.