### PR TITLE
fix!: add missing smart comment prefix

### DIFF
--- a/src/deploy/table_account_block.sql
+++ b/src/deploy/table_account_block.sql
@@ -13,7 +13,7 @@ CREATE TABLE vibetype.account_block (
 );
 
 COMMENT ON TABLE vibetype.account_block IS E'@omit update\nBlocking of one account by another.';
-COMMENT ON COLUMN vibetype.account_block.id IS '@omit create\nThe account block''s internal id.';
+COMMENT ON COLUMN vibetype.account_block.id IS E'@omit create\nThe account block''s internal id.';
 COMMENT ON COLUMN vibetype.account_block.blocked_account_id IS 'The account id of the user who is blocked.';
 COMMENT ON COLUMN vibetype.account_block.created_at IS E'@omit create\nTimestamp of when the account block was created.';
 COMMENT ON COLUMN vibetype.account_block.created_by IS 'The account id of the user who created the account block.';

--- a/src/deploy/table_legal_term_acceptance.sql
+++ b/src/deploy/table_legal_term_acceptance.sql
@@ -9,7 +9,7 @@ CREATE TABLE vibetype.legal_term_acceptance (
   created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON TABLE vibetype.legal_term_acceptance IS '@omit update,delete\nTracks each user account''s acceptance of legal terms and conditions.';
+COMMENT ON TABLE vibetype.legal_term_acceptance IS E'@omit update,delete\nTracks each user account''s acceptance of legal terms and conditions.';
 COMMENT ON COLUMN vibetype.legal_term_acceptance.id IS E'@omit create\nUnique identifier for this legal term acceptance record. Automatically generated for each new acceptance.';
 COMMENT ON COLUMN vibetype.legal_term_acceptance.account_id IS 'The user account ID that accepted the legal terms. If the account is deleted, this acceptance record will also be deleted.';
 COMMENT ON COLUMN vibetype.legal_term_acceptance.legal_term_id IS 'The ID of the legal terms that were accepted. Deletion of these legal terms is restricted while they are still referenced in this table.';

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -3095,7 +3095,8 @@ Blocking of one account by another.';
 -- Name: COLUMN account_block.id; Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON COLUMN vibetype.account_block.id IS '@omit create\nThe account block''s internal id.';
+COMMENT ON COLUMN vibetype.account_block.id IS '@omit create
+The account block''s internal id.';
 
 
 --
@@ -4185,7 +4186,8 @@ ALTER TABLE vibetype.legal_term_acceptance OWNER TO ci;
 -- Name: TABLE legal_term_acceptance; Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON TABLE vibetype.legal_term_acceptance IS '@omit update,delete\nTracks each user account''s acceptance of legal terms and conditions.';
+COMMENT ON TABLE vibetype.legal_term_acceptance IS '@omit update,delete
+Tracks each user account''s acceptance of legal terms and conditions.';
 
 
 --


### PR DESCRIPTION
`E` was missing in some cases