### PR TITLE
feat(preference)!: add id

### DIFF
--- a/src/deploy/table_preference_event_category.sql
+++ b/src/deploy/table_preference_event_category.sql
@@ -1,12 +1,14 @@
 BEGIN;
 
 CREATE TABLE vibetype.preference_event_category (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
   account_id  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   category_id UUID NOT NULL REFERENCES vibetype.event_category(id) ON DELETE CASCADE,
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-  PRIMARY KEY (account_id, category_id)
+  UNIQUE (account_id, category_id)
 );
 
 COMMENT ON TABLE vibetype.preference_event_category IS 'Event categories a user account is interested in (M:N relationship).';

--- a/src/deploy/table_preference_event_format.sql
+++ b/src/deploy/table_preference_event_format.sql
@@ -1,12 +1,14 @@
 BEGIN;
 
 CREATE TABLE vibetype.preference_event_format (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
   account_id  UUID NOT NULL REFERENCES vibetype.account(id) ON DELETE CASCADE,
   format_id   UUID NOT NULL REFERENCES vibetype.event_format(id) ON DELETE CASCADE,
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-  PRIMARY KEY (account_id, format_id)
+  UNIQUE (account_id, format_id)
 );
 
 COMMENT ON TABLE vibetype.preference_event_format IS 'Event formats a user account is interested in (M:N relationship).';

--- a/src/deploy/table_preference_event_size.sql
+++ b/src/deploy/table_preference_event_size.sql
@@ -1,12 +1,14 @@
 BEGIN;
 
 CREATE TABLE vibetype.preference_event_size (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
   account_id  UUID REFERENCES vibetype.account(id) ON DELETE CASCADE,
   event_size  vibetype.event_size,
 
   created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-  PRIMARY KEY (account_id, event_size)
+  UNIQUE (account_id, event_size)
 );
 
 COMMENT ON TABLE vibetype.preference_event_size IS 'Table for the user accounts'' preferred event sizes (M:N relationship).';

--- a/src/verify/table_preference_event_category.sql
+++ b/src/verify/table_preference_event_category.sql
@@ -1,11 +1,12 @@
 BEGIN;
 
-SELECT a.account_id,
-       a.category_id,
-       a.created_at,
+SELECT p.id,
+       p.account_id,
+       p.category_id,
+       p.created_at,
        c.name
-FROM vibetype.preference_event_category a
-  JOIN vibetype.event_category c ON a.category_id = c.id
+FROM vibetype.preference_event_category p
+  JOIN vibetype.event_category c ON p.category_id = c.id
 WHERE FALSE;
 
 ROLLBACK;

--- a/src/verify/table_preference_event_format.sql
+++ b/src/verify/table_preference_event_format.sql
@@ -1,11 +1,12 @@
 BEGIN;
 
-SELECT a.account_id,
-       a.format_id,
-       a.created_at,
+SELECT p.id,
+       p.account_id,
+       p.format_id,
+       p.created_at,
        f.name
-FROM vibetype.preference_event_format a
-  JOIN vibetype.event_format f ON a.format_id = f.id
+FROM vibetype.preference_event_format p
+  JOIN vibetype.event_format f ON p.format_id = f.id
 WHERE FALSE;
 
 ROLLBACK;

--- a/src/verify/table_preference_event_size.sql
+++ b/src/verify/table_preference_event_size.sql
@@ -1,6 +1,7 @@
 BEGIN;
 
-SELECT account_id,
+SELECT id,
+       account_id,
        event_size,
        created_at
 FROM vibetype.preference_event_size WHERE FALSE;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -4195,6 +4195,7 @@ Timestamp showing when the legal terms were accepted, set automatically at the t
 --
 
 CREATE TABLE vibetype.preference_event_category (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     account_id uuid NOT NULL,
     category_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -4229,6 +4230,7 @@ COMMENT ON COLUMN vibetype.preference_event_category.category_id IS 'An event ca
 --
 
 CREATE TABLE vibetype.preference_event_format (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
     account_id uuid NOT NULL,
     format_id uuid NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -4330,8 +4332,9 @@ COMMENT ON COLUMN vibetype.preference_event_location.created_by IS 'Reference to
 --
 
 CREATE TABLE vibetype.preference_event_size (
-    account_id uuid NOT NULL,
-    event_size vibetype.event_size NOT NULL,
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    account_id uuid,
+    event_size vibetype.event_size,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
@@ -5358,11 +5361,27 @@ ALTER TABLE ONLY vibetype.legal_term
 
 
 --
+-- Name: preference_event_category preference_event_category_account_id_category_id_key; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.preference_event_category
+    ADD CONSTRAINT preference_event_category_account_id_category_id_key UNIQUE (account_id, category_id);
+
+
+--
 -- Name: preference_event_category preference_event_category_pkey; Type: CONSTRAINT; Schema: vibetype; Owner: ci
 --
 
 ALTER TABLE ONLY vibetype.preference_event_category
-    ADD CONSTRAINT preference_event_category_pkey PRIMARY KEY (account_id, category_id);
+    ADD CONSTRAINT preference_event_category_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: preference_event_format preference_event_format_account_id_format_id_key; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.preference_event_format
+    ADD CONSTRAINT preference_event_format_account_id_format_id_key UNIQUE (account_id, format_id);
 
 
 --
@@ -5370,7 +5389,7 @@ ALTER TABLE ONLY vibetype.preference_event_category
 --
 
 ALTER TABLE ONLY vibetype.preference_event_format
-    ADD CONSTRAINT preference_event_format_pkey PRIMARY KEY (account_id, format_id);
+    ADD CONSTRAINT preference_event_format_pkey PRIMARY KEY (id);
 
 
 --
@@ -5390,11 +5409,19 @@ ALTER TABLE ONLY vibetype.preference_event_location
 
 
 --
+-- Name: preference_event_size preference_event_size_account_id_event_size_key; Type: CONSTRAINT; Schema: vibetype; Owner: ci
+--
+
+ALTER TABLE ONLY vibetype.preference_event_size
+    ADD CONSTRAINT preference_event_size_account_id_event_size_key UNIQUE (account_id, event_size);
+
+
+--
 -- Name: preference_event_size preference_event_size_pkey; Type: CONSTRAINT; Schema: vibetype; Owner: ci
 --
 
 ALTER TABLE ONLY vibetype.preference_event_size
-    ADD CONSTRAINT preference_event_size_pkey PRIMARY KEY (account_id, event_size);
+    ADD CONSTRAINT preference_event_size_pkey PRIMARY KEY (id);
 
 
 --


### PR DESCRIPTION
Adds an `id` column to the preference tables which currently have a composite primary key. This helps reduce some frontend complexity, see https://nearform.com/open-source/urql/docs/graphcache/.