### PR TITLE
chore(git): initialize `nvm` in hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,7 @@
+#!/bin/sh
+
+export NVM_DIR="$HOME/.nvm"
+# shellcheck source=/dev/null
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
 pnpm commitlint --edit "$1"


### PR DESCRIPTION
Husky uses sh and does not source files like `.bashrc` or `.zshrc`. As the development instructions for maevsi instruct to use nvm, we can work around the "Node / pnpm not found" error in GUI applications like GitKraken by sourcing the nvm initializer in the Git hooks, I think.

User-based configurations would require additional setup instructions which a developer should not need to care about imo. Of course this change expects the nvm initialization script to be at in a specific place, but I think we can assume that this standard path is the same on all developers' machines for now.