### PR TITLE
feat(event-favorite): grant select for anonymous

### DIFF
--- a/src/deploy/2025-06-13_event_favorite_anonymous.sql
+++ b/src/deploy/2025-06-13_event_favorite_anonymous.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+GRANT SELECT ON TABLE vibetype.event_favorite TO vibetype_anonymous;
+
+COMMIT;

--- a/src/revert/2025-06-13_event_favorite_anonymous.sql
+++ b/src/revert/2025-06-13_event_favorite_anonymous.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+REVOKE SELECT ON TABLE vibetype.event_favorite FROM vibetype_anonymous;
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -92,3 +92,4 @@ function_account_location_update [privilege_execute_revoke schema_public table_a
 table_preference_event_location [schema_public table_account_public role_account function_invoker_account_id] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Stores preferred event locations for user accounts, including coordinates and search radius.
 role_zammad 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add role zammad.
 database_zammad [role_zammad] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add the database for zammad.
+2025-06-13_event_favorite_anonymous [table_event_favorite role_anonymous] 2025-06-13T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Grant select permission for anonymous users on event favorites.

--- a/src/verify/2025-06-13_event_favorite_anonymous.sql
+++ b/src/verify/2025-06-13_event_favorite_anonymous.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_favorite', 'SELECT'));
+END $$;
+
+ROLLBACK;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -7431,6 +7431,7 @@ GRANT SELECT,INSERT,DELETE ON TABLE vibetype.event_category_mapping TO vibetype_
 --
 
 GRANT SELECT,INSERT,DELETE ON TABLE vibetype.event_favorite TO vibetype_account;
+GRANT SELECT ON TABLE vibetype.event_favorite TO vibetype_anonymous;
 
 
 --

--- a/test/logic/main.sql
+++ b/test/logic/main.sql
@@ -43,6 +43,7 @@ GRANT USAGE ON SCHEMA vibetype_test TO vibetype_anonymous, vibetype_account;
 \i scenario/model/account.sql
 \i scenario/model/authenticate.sql
 \i scenario/model/event.sql
+\i scenario/model/event_favorite.sql
 \i scenario/model/friendship.sql
 \i scenario/model/guest.sql
 -- \i scenario/model/invite.sql -- TODO: remove comment when PR "feat(notification)!: inherit invitations" has been merged

--- a/test/logic/scenario/model/event_favorite.sql
+++ b/test/logic/scenario/model/event_favorite.sql
@@ -1,0 +1,56 @@
+\echo test_event_favorite...
+
+BEGIN;
+
+SAVEPOINT event_favorite_account;
+DO $$
+DECLARE
+  _account_favorite_owner UUID;
+  _account_other UUID;
+  _count INTEGER;
+  _event UUID;
+BEGIN
+  _account_favorite_owner := vibetype_test.account_registration_verified('favorite-owner', 'email+a@example.com');
+  _account_other := vibetype_test.account_registration_verified('other', 'email+b@example.com');
+  _event := vibetype_test.event_create(_account_favorite_owner, 'Name', 'slug', '1970-01-01 00:00', 'public');
+
+  INSERT INTO vibetype.event_favorite (event_id, created_by)
+    VALUES (_event, _account_favorite_owner);
+
+  PERFORM vibetype_test.invoker_set(_account_favorite_owner);
+  SELECT COUNT(1) INTO _count FROM vibetype.event_favorite;
+
+  IF _count <> 1 THEN
+    RAISE EXCEPTION 'Exactly one event favorite should be returned for the account that has one.';
+  END IF;
+
+  PERFORM vibetype_test.invoker_set(_account_other);
+  SELECT COUNT(1) INTO _count FROM vibetype.event_favorite;
+
+  IF _count <> 0 THEN
+    RAISE EXCEPTION 'No event favorites should be returned for an account that hasn''t set any.';
+  END IF;
+END $$;
+ROLLBACK TO SAVEPOINT event_favorite_account;
+
+
+SAVEPOINT event_favorite_anonymous;
+DO $$
+DECLARE
+  _account UUID;
+  _event UUID;
+BEGIN
+  _account := vibetype_test.account_registration_verified('username', 'email@example.com');
+  _event := vibetype_test.event_create(_account, 'Name', 'slug', '1970-01-01 00:00', 'public');
+
+  INSERT INTO vibetype.event_favorite (event_id, created_by) VALUES (_event, _account);
+
+  PERFORM vibetype_test.invoker_set_anonymous();
+
+  IF (SELECT 1 FROM vibetype.event_favorite) IS NOT NULL THEN
+    RAISE EXCEPTION 'No event favorites should be returned for anonymous users.';
+  END IF;
+END $$;
+ROLLBACK TO SAVEPOINT event_favorite_anonymous;
+
+ROLLBACK;


### PR DESCRIPTION
While developing the frontend I noticed that it would noticeably reduce frontend code complexity and package size if we allowed anonymous users to query tables that we don't expect to return any data to them. Of course this increases load on the database somewhat but spammers should be taken care of by our session logic before too many requests hit the database and the load increase should be acceptable for us compared to the increase in package size and code complexity with the current configuration.

Also, I wrote this change as an incremental migration for the first time so that it is not breaking. I expect to merge all incremental changes back into our existing files from time to time when the amount of changes accumulated make sense to do so. This time I'll submit the matching beta branch PR right away to test this workflow.