### PR TITLE
feat(search)!: add search vectors for all supported languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN docker-entrypoint.sh postgres & \
   && sqitch --chdir src deploy -t db:pg://ci:postgres@/ci_database \
   && pg_dump -s -h localhost -U ci -p 5432 ci_database | sed -e '/^-- Dumped/d' > schema.sql \
   && psql -h localhost -U ci -d ci_database -q -f ./test/logic/main.sql \
-    -v TEST_DIRECTORY=./test/logic -v ON_ERROR_STOP=on \
+    -v TEST_DIRECTORY=./test/logic \
   && sqitch --chdir src revert -t db:pg://ci:postgres@/ci_database
 
 ##############################

--- a/src/deploy/function_event_search.sql
+++ b/src/deploy/function_event_search.sql
@@ -11,13 +11,15 @@ BEGIN
 
   RETURN QUERY
   SELECT
-    *
+    e.*
   FROM
-    vibetype.event
+    vibetype.event e
+    JOIN vibetype.event_search_vector esv ON esv.event_id = e.id
   WHERE
-    search_vector @@ websearch_to_tsquery(ts_config, event_search.query)
+    esv.search_vector @@ websearch_to_tsquery(ts_config, event_search.query)
+    AND esv.language = event_search.language
   ORDER BY
-    ts_rank_cd(search_vector, websearch_to_tsquery(ts_config, event_search.query)) DESC;
+    ts_rank_cd(esv.search_vector, websearch_to_tsquery(ts_config, event_search.query)) DESC;
 END;
 $$ LANGUAGE PLPGSQL STABLE SECURITY INVOKER;
 

--- a/src/deploy/table_event_search_vector.sql
+++ b/src/deploy/table_event_search_vector.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+CREATE TABLE vibetype.event_search_vector (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id                 UUID REFERENCES vibetype.event(id) ON DELETE SET NULL,
+  language                 vibetype.language NOT NULL,
+  search_vector            TSVECTOR,
+
+  UNIQUE (event_id, language)
+);
+
+COMMENT ON TABLE vibetype.event_search_vector IS 'A language-specific search vecotr for an event.';
+COMMENT ON COLUMN vibetype.event_search_vector.id IS E'@omit create,update\nThe records''s internal id.';
+COMMENT ON COLUMN vibetype.event_search_vector.event_id IS 'The reference to the event.';
+COMMENT ON COLUMN vibetype.event_search_vector.language IS 'The language associated with the search vector.';
+COMMENT ON COLUMN vibetype.event_search_vector.search_vector IS E'@omit\nA vector used for full-text search on events.';
+
+CREATE INDEX idx_event_search_vector ON vibetype.event_search_vector USING gin (search_vector);
+
+COMMENT ON INDEX vibetype.idx_event_search_vector IS 'GIN index on the search vector to improve full-text search performance.';
+
+GRANT SELECT ON TABLE vibetype.event_search_vector TO vibetype_anonymous;
+GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE vibetype.event_search_vector TO vibetype_account;
+
+CREATE POLICY event_search_vector_select ON vibetype.event_search_vector FOR SELECT
+USING (
+  event_id IN (SELECT id FROM vibetype_private.event_policy_select())
+);
+
+COMMIT;

--- a/src/deploy/table_event_search_vector.sql
+++ b/src/deploy/table_event_search_vector.sql
@@ -9,11 +9,11 @@ CREATE TABLE vibetype.event_search_vector (
   UNIQUE (event_id, language)
 );
 
-COMMENT ON TABLE vibetype.event_search_vector IS 'A language-specific search vecotr for an event.';
-COMMENT ON COLUMN vibetype.event_search_vector.id IS E'@omit create,update\nThe records''s internal id.';
+COMMENT ON TABLE vibetype.event_search_vector IS E'@omit create,update,delete\nA language-specific search vector for an event.';
+COMMENT ON COLUMN vibetype.event_search_vector.id IS 'The records''s internal id.';
 COMMENT ON COLUMN vibetype.event_search_vector.event_id IS 'The reference to the event.';
 COMMENT ON COLUMN vibetype.event_search_vector.language IS 'The language associated with the search vector.';
-COMMENT ON COLUMN vibetype.event_search_vector.search_vector IS E'@omit\nA vector used for full-text search on events.';
+COMMENT ON COLUMN vibetype.event_search_vector.search_vector IS 'A vector used for full-text search on events.';
 
 CREATE INDEX idx_event_search_vector ON vibetype.event_search_vector USING gin (search_vector);
 

--- a/src/revert/table_event.sql
+++ b/src/revert/table_event.sql
@@ -2,7 +2,6 @@ BEGIN;
 
 DROP TRIGGER vibetype_trigger_event_search_vector ON vibetype.event;
 DROP FUNCTION vibetype.trigger_event_search_vector();
-DROP INDEX vibetype.idx_event_search_vector;
 DROP TABLE vibetype.event;
 
 COMMIT;

--- a/src/revert/table_event_search_vector.sql
+++ b/src/revert/table_event_search_vector.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX vibetype.idx_event_search_vector;
+DROP TABLE vibetype.event_search_vector;
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -92,3 +92,4 @@ function_account_location_update [privilege_execute_revoke schema_public table_a
 table_preference_event_location [schema_public table_account_public role_account function_invoker_account_id] 1970-01-01T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Stores preferred event locations for user accounts, including coordinates and search radius.
 role_zammad 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add role zammad.
 database_zammad [role_zammad] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add the database for zammad.
+table_event_search_vector [schema_public table_event role_account role_anonymous] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add table event_search_vector.

--- a/src/verify/table_event.sql
+++ b/src/verify/table_event.sql
@@ -14,8 +14,7 @@ SELECT id,
        url,
        visibility,
        created_at,
-       created_by,
-       search_vector
+       created_by
 FROM vibetype.event WHERE FALSE;
 
 

--- a/src/verify/table_event_search_vector.sql
+++ b/src/verify/table_event_search_vector.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+SELECT id,
+       event_id,
+       language,
+       search_vector
+FROM vibetype.event_search_vector WHERE FALSE;
+
+\set role_service_vibetype_username `cat /run/secrets/postgres_role_service_vibetype_username`
+SET local role.vibetype_username TO :'role_service_vibetype_username';
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_search_vector', 'SELECT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_search_vector', 'INSERT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_search_vector', 'UPDATE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_account', 'vibetype.event_search_vector', 'DELETE'));
+  ASSERT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_search_vector', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_search_vector', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_search_vector', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.event_search_vector', 'DELETE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_search_vector', 'SELECT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_search_vector', 'INSERT'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_search_vector', 'UPDATE'));
+  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.event_search_vector', 'DELETE'));
+END $$;
+
+ROLLBACK;
+
+ROLLBACK;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -1226,13 +1226,15 @@ BEGIN
 
   RETURN QUERY
   SELECT
-    *
+    e.*
   FROM
-    vibetype.event
+    vibetype.event e
+    JOIN vibetype.event_search_vector esv ON esv.event_id = e.id
   WHERE
-    search_vector @@ websearch_to_tsquery(ts_config, event_search.query)
+    esv.search_vector @@ websearch_to_tsquery(ts_config, event_search.query)
+    AND esv.language = event_search.language
   ORDER BY
-    ts_rank_cd(search_vector, websearch_to_tsquery(ts_config, event_search.query)) DESC;
+    ts_rank_cd(esv.search_vector, websearch_to_tsquery(ts_config, event_search.query)) DESC;
 END;
 $$;
 
@@ -3863,15 +3865,15 @@ ALTER TABLE vibetype.event_search_vector OWNER TO ci;
 -- Name: TABLE event_search_vector; Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON TABLE vibetype.event_search_vector IS 'A language-specific search vecotr for an event.';
+COMMENT ON TABLE vibetype.event_search_vector IS '@omit create,update,delete
+A language-specific search vector for an event.';
 
 
 --
 -- Name: COLUMN event_search_vector.id; Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON COLUMN vibetype.event_search_vector.id IS '@omit create,update
-The records''s internal id.';
+COMMENT ON COLUMN vibetype.event_search_vector.id IS 'The records''s internal id.';
 
 
 --
@@ -3892,8 +3894,7 @@ COMMENT ON COLUMN vibetype.event_search_vector.language IS 'The language associa
 -- Name: COLUMN event_search_vector.search_vector; Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON COLUMN vibetype.event_search_vector.search_vector IS '@omit
-A vector used for full-text search on events.';
+COMMENT ON COLUMN vibetype.event_search_vector.search_vector IS 'A vector used for full-text search on events.';
 
 
 --

--- a/test/logic/main.sql
+++ b/test/logic/main.sql
@@ -1,3 +1,4 @@
+\set ON_ERROR_STOP on
 \echo TEST_DIRECTORY = :TEST_DIRECTORY
 \cd :TEST_DIRECTORY
 \! pwd
@@ -43,6 +44,7 @@ GRANT USAGE ON SCHEMA vibetype_test TO vibetype_anonymous, vibetype_account;
 \i scenario/model/account.sql
 \i scenario/model/authenticate.sql
 \i scenario/model/event.sql
+\i scenario/model/event_search.sql
 \i scenario/model/event_favorite.sql
 \i scenario/model/friendship.sql
 \i scenario/model/guest.sql

--- a/test/logic/scenario/model/account_block.sql
+++ b/test/logic/scenario/model/account_block.sql
@@ -77,9 +77,9 @@ BEGIN
   contactCA := vibetype_test.contact_create(accountC, 'a@example.com');
   contactCB := vibetype_test.contact_create(accountC, 'b@example.com');
 
-  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', '2025-06-01 20:00', 'public');
-  eventB := vibetype_test.event_create(accountB, 'Event by B', 'event-by-b', '2025-06-01 20:00', 'public');
-  eventC := vibetype_test.event_create(accountC, 'Event by C', 'event-by-c', '2025-06-01 20:00', 'public');
+  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', 'event by A', null, '2025-06-01 20:00', 'public');
+  eventB := vibetype_test.event_create(accountB, 'Event by B', 'event-by-b', 'event by B', null, '2025-06-01 20:00', 'public');
+  eventC := vibetype_test.event_create(accountC, 'Event by C', 'event-by-c', 'event by C', null, '2025-06-01 20:00', 'public');
 
   PERFORM vibetype_test.event_category_create('category');
   PERFORM vibetype_test.event_category_mapping_create(accountA, eventA, 'category');

--- a/test/logic/scenario/model/event_favorite.sql
+++ b/test/logic/scenario/model/event_favorite.sql
@@ -12,7 +12,7 @@ DECLARE
 BEGIN
   _account_favorite_owner := vibetype_test.account_registration_verified('favorite-owner', 'email+a@example.com');
   _account_other := vibetype_test.account_registration_verified('other', 'email+b@example.com');
-  _event := vibetype_test.event_create(_account_favorite_owner, 'Name', 'slug', '1970-01-01 00:00', 'public');
+  _event := vibetype_test.event_create(_account_favorite_owner, 'Name', 'slug', 'Description', null, '1970-01-01 00:00', 'public');
 
   INSERT INTO vibetype.event_favorite (event_id, created_by)
     VALUES (_event, _account_favorite_owner);
@@ -41,7 +41,7 @@ DECLARE
   _event UUID;
 BEGIN
   _account := vibetype_test.account_registration_verified('username', 'email@example.com');
-  _event := vibetype_test.event_create(_account, 'Name', 'slug', '1970-01-01 00:00', 'public');
+  _event := vibetype_test.event_create(_account, 'Name', 'slug', 'Description', null, '1970-01-01 00:00', 'public');
 
   INSERT INTO vibetype.event_favorite (event_id, created_by) VALUES (_event, _account);
 

--- a/test/logic/scenario/model/event_search.sql
+++ b/test/logic/scenario/model/event_search.sql
@@ -1,0 +1,79 @@
+\echo test_event_search...
+
+-- make sure the client encoding matches the encoding of database tables
+\encoding UTF8
+
+BEGIN;
+
+DO $$
+DECLARE
+  accountA  UUID;
+  event1    UUID;
+  event2    UUID;
+  supported_languages vibetype.language[];
+  number_of_supported_languages INTEGER;
+  rec       RECORD;
+  _language vibetype.language;
+  _query    TEXT;
+  event_rec vibetype.event%ROWTYPE;
+  
+BEGIN
+
+  accountA := vibetype_test.account_registration_verified('a', 'a@example.com');
+
+  event1 := vibetype_test.event_create(accountA, 'Event 1', 'event-1', 'This is the perfect place for all lonely hearts.', 'en'::vibetype.language, '2025-07-01 20:00', 'public');
+  event2 := vibetype_test.event_create(accountA, 'Event 2', 'event-2', 'Die besten Tänze machen den Abend zu einem unvergesslichen Erlebnis.', 'de'::vibetype.language, '2025-07-01 20:00', 'public');
+
+  supported_languages := enum_range(NULL::vibetype.language);
+  number_of_supported_languages := array_length(supported_languages, 1);
+  
+  FOR rec IN
+    SELECT event_id, count(*) n
+    FROM vibetype.event_search_vector
+    WHERE event_id IN (event1, event2)
+    GROUP BY event_id
+    HAVING count(*) <> number_of_supported_languages
+  LOOP
+    RAISE EXCEPTION '%: number of text vectors does not match the number of available languages', rec.event_id;
+  END LOOP;
+
+/*
+  FOR rec IN
+    SELECT e.name, e.description, esv.language, esv.search_vector
+    FROM vibetype.event e JOIN vibetype.event_search_vector esv ON e.id = esv.event_id
+    WHERE e.id IN (event1, event2)
+  LOOP
+    RAISE NOTICE '%, %, %, %', rec.name, rec.description, rec.language, rec.search_vector;
+  END LOOP;
+*/
+
+  -- english text search vectors contain 'heart' and 'Tänze'
+  -- german text search vectors contain 'heart' and 'tanz'
+
+  FOREACH _language IN ARRAY supported_languages
+  LOOP
+    FOREACH _query IN ARRAY ARRAY['heart', 'hearts', 'tanz', 'tänze']
+    LOOP
+        SELECT * INTO event_rec 
+        FROM vibetype.event_search(_query, _language);
+        
+        IF _query = 'tanz' and _language = 'en' THEN
+          -- query result should be empty
+          IF event_rec.id IS NOT NULL THEN
+            RAISE EXCEPTION 'query result should be empty';
+          END IF;
+        ELSE
+          -- query result should not be empty
+          IF _query IN ('heart', 'hearts') AND event_rec.id != event1 THEN
+            RAISE EXCEPTION 'id in result should have been %', event1;
+          ELSEIF _query IN ('tanz', 'tänze') AND event_rec.id != event2 THEN
+            RAISE EXCEPTION 'id in result should have been %', event2;
+          END IF;
+        END IF;
+    
+    END LOOP;
+  END LOOP;
+
+END $$;
+
+ROLLBACK;

--- a/test/logic/scenario/model/guest.sql
+++ b/test/logic/scenario/model/guest.sql
@@ -25,7 +25,7 @@ BEGIN
   contactAB := vibetype_test.contact_create(accountA, 'b@example.com');
   contactAC := vibetype_test.contact_create(accountA, 'c@example.com');
 
-  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', '2025-06-01 20:00', 'public');
+  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', 'Description', null, '2025-06-01 20:00', 'public');
 
   PERFORM vibetype_test.invoker_set(accountA);
 

--- a/test/logic/scenario/model/invite.sql
+++ b/test/logic/scenario/model/invite.sql
@@ -20,7 +20,7 @@ BEGIN
   accountA := vibetype_test.account_registration_verified('a', 'a@example.com');
   accountB := vibetype_test.account_registration_verified('b', 'b@example.com');
   contactAB := vibetype_test.contact_create(accountA, 'b@example.com');
-  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', '2025-06-01 20:00', 'public');
+  eventA := vibetype_test.event_create(accountA, 'Event by A', 'event-by-a', 'Description', null, '2025-06-01 20:00', 'public');
   guestAB := vibetype_test.guest_create(accountA, eventA, contactAB);
 
   PERFORM vibetype_test.invoker_set(accountA);

--- a/test/logic/utility/model/event.sql
+++ b/test/logic/utility/model/event.sql
@@ -2,6 +2,8 @@ CREATE OR REPLACE FUNCTION vibetype_test.event_create (
   _created_by UUID,
   _name TEXT,
   _slug TEXT,
+  _description TEXT,
+  _language vibetype.language,
   _start TEXT,
   _visibility TEXT
 ) RETURNS UUID AS $$
@@ -11,8 +13,8 @@ BEGIN
   SET LOCAL ROLE = 'vibetype_account';
   EXECUTE 'SET LOCAL jwt.claims.account_id = ''' || _created_by || '''';
 
-  INSERT INTO vibetype.event(created_by, name, slug, start, visibility)
-  VALUES (_created_by, _name, _slug, _start::TIMESTAMP WITH TIME ZONE, _visibility::vibetype.event_visibility)
+  INSERT INTO vibetype.event(created_by, name, slug, description, language, start, visibility)
+  VALUES (_created_by, _name, _slug, _description, _language, _start::TIMESTAMP WITH TIME ZONE, _visibility::vibetype.event_visibility)
   RETURNING id INTO _id;
 
   SET LOCAL ROLE NONE;
@@ -20,7 +22,7 @@ BEGIN
   RETURN _id;
 END $$ LANGUAGE plpgsql;
 
-GRANT EXECUTE ON FUNCTION vibetype_test.event_create(UUID, TEXT, TEXT, TEXT, TEXT) TO vibetype_account;
+GRANT EXECUTE ON FUNCTION vibetype_test.event_create(UUID, TEXT, TEXT, TEXT, vibetype.language, TEXT, TEXT) TO vibetype_account;
 
 
 CREATE OR REPLACE FUNCTION vibetype_test.event_select_address_coordinates(

--- a/test/logic/utility/test/cleanup.sql
+++ b/test/logic/utility/test/cleanup.sql
@@ -10,15 +10,17 @@ BEGIN
   */
   FOR rec IN
     SELECT n.nspname, p.proname,
-      CASE p.prokind WHEN 'f' THEN 'FUNCTION' ELSE 'PROCEDURE' END prokind,
+      CASE p.prokind WHEN 'f' THEN 'FUNCTION' ELSE 'PROCEDURE' END prokind, p.proargtypes,
       array_to_string(ARRAY(
-        SELECT CASE WHEN substring(t.typname for 1) = '_' THEN substring(t.typname FROM 2) || '[]' ELSE t.typname END
-        FROM UNNEST(p.proargtypes) WITH ORDINALITY JOIN pg_type t ON UNNEST = t.oid
+        SELECT tn.nspname || '.' ||CASE WHEN substring(t.typname for 1) = '_' THEN substring(t.typname FROM 2) || '[]' ELSE t.typname END
+        FROM UNNEST(p.proargtypes) WITH ORDINALITY
+          JOIN pg_type t ON UNNEST = t.oid
+          JOIN pg_namespace tn ON t.typnamespace = tn.oid
         ORDER BY ordinality
       ), ',') args
     FROM pg_proc p
       JOIN pg_namespace n ON p.pronamespace = n.oid
-    WHERE n.nspname = 'vibetype_test'  AND p.prokind IN ('f', 'p')
+    WHERE n.nspname = 'vibetype_test'  AND p.prokind IN ('f', 'p') AND proname = 'event_create'
   LOOP
     EXECUTE format('DROP %s %s.%s(%s)', rec.prokind, rec.nspname, rec.proname, rec.args);
   END LOOP;


### PR DESCRIPTION
A new table `vibetype.event_search_vector` to accommodate search vectors for every supported language, so each event will have multiple search vectors.