### PR TITLE
feat(account): specify unicode collation for username

### DIFF
--- a/src/deploy/2025-07-04_account_public_username_collate.sql
+++ b/src/deploy/2025-07-04_account_public_username_collate.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE vibetype.account
+  ALTER COLUMN username
+  TYPE TEXT COLLATE unicode;
+
+COMMIT;

--- a/src/revert/2025-07-04_account_public_username_collate.sql
+++ b/src/revert/2025-07-04_account_public_username_collate.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE vibetype.account
+  ALTER COLUMN username
+  TYPE TEXT COLLATE "default";
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -94,3 +94,4 @@ role_zammad 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # A
 database_zammad [role_zammad] 1970-01-01T00:00:00Z Sven Thelemann <sven.thelemann@t-online.de> # Add the database for zammad.
 2025-06-13_event_favorite_anonymous [table_event_favorite role_anonymous] 2025-06-13T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Grant select permission for anonymous users on event favorites.
 2025-06-23_account_public_omits [schema_public table_account_public] 2025-06-23T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Correct table permissions and omits for public account.
+2025-07-04_account_public_username_collate [schema_public table_account_public] 2025-07-04T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Specify Unicode collation for usernames.

--- a/src/verify/2025-07-04_account_public_username_collate.sql
+++ b/src/verify/2025-07-04_account_public_username_collate.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+DO $$
+DECLARE
+  actual_collation TEXT;
+BEGIN
+  SELECT c.collname INTO actual_collation
+  FROM pg_attribute a
+  JOIN pg_class t ON a.attrelid = t.oid
+  JOIN pg_namespace n ON t.relnamespace = n.oid
+  LEFT JOIN pg_collation c ON a.attcollation = c.oid
+  WHERE t.relname = 'account'
+    AND a.attname = 'username'
+    AND a.attnum > 0
+    AND NOT a.attisdropped;
+
+  IF actual_collation IS DISTINCT FROM 'unicode' THEN
+    RAISE EXCEPTION 'Collation mismatch: expected unicode, found %', actual_collation;
+  END IF;
+END $$;
+
+ROLLBACK;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -3064,7 +3064,7 @@ CREATE TABLE vibetype.account (
     id uuid NOT NULL,
     description text,
     imprint text,
-    username text NOT NULL,
+    username text NOT NULL COLLATE pg_catalog.unicode,
     CONSTRAINT account_description_check CHECK ((char_length(description) < 1000)),
     CONSTRAINT account_imprint_check CHECK ((char_length(imprint) < 10000)),
     CONSTRAINT account_username_check CHECK (((char_length(username) < 100) AND (username ~ '^[-A-Za-z0-9]+$'::text)))


### PR DESCRIPTION
User search would benefit from ordered results like

- name
- Name
- user
- User

instead of

- Name
- User
- name
- user

so Unicode collation is added to the username column of the account table.