### PR TITLE
fix(account): disallow selecting blocked

### DIFF
--- a/src/deploy/2025-07-06_account_public_policy_block.sql
+++ b/src/deploy/2025-07-06_account_public_policy_block.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+DROP POLICY account_select ON vibetype.account;
+
+CREATE POLICY account_select ON vibetype.account FOR SELECT USING (
+  id NOT IN (
+    SELECT id FROM vibetype_private.account_block_ids()
+  )
+);
+
+COMMIT;

--- a/src/revert/2025-07-06_account_public_policy_block.sql
+++ b/src/revert/2025-07-06_account_public_policy_block.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+DROP POLICY account_select ON vibetype.account;
+
+CREATE POLICY account_select ON vibetype.account FOR SELECT USING (
+  TRUE
+);
+
+COMMIT;

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -96,3 +96,4 @@ database_zammad [role_zammad] 1970-01-01T00:00:00Z Sven Thelemann <sven.theleman
 2025-06-23_account_public_omits [schema_public table_account_public] 2025-06-23T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Correct table permissions and omits for public account.
 2025-07-04_account_public_username_collate [schema_public table_account_public] 2025-07-04T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Specify Unicode collation for usernames.
 2025-07-06_account_delete_check_event_drop [privilege_execute_revoke schema_public schema_private table_account_private extension_pgcrypto role_account] 2025-07-06T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Prevent access to blocked accounts.
+2025-07-06_account_public_policy_block [schema_public table_account_public] 2025-07-06T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Prevent access to blocked accounts.

--- a/src/verify/2025-07-06_account_public_policy_block.sql
+++ b/src/verify/2025-07-06_account_public_policy_block.sql
@@ -1,0 +1,3 @@
+BEGIN;
+
+ROLLBACK;

--- a/test/fixture/schema.definition.sql
+++ b/test/fixture/schema.definition.sql
@@ -6168,7 +6168,8 @@ CREATE POLICY account_block_all ON vibetype.account_block USING ((created_by = v
 -- Name: account account_select; Type: POLICY; Schema: vibetype; Owner: ci
 --
 
-CREATE POLICY account_select ON vibetype.account FOR SELECT USING (true);
+CREATE POLICY account_select ON vibetype.account FOR SELECT USING ((NOT (id IN ( SELECT account_block_ids.id
+   FROM vibetype_private.account_block_ids() account_block_ids(id)))));
 
 
 --


### PR DESCRIPTION
After blocking an account, the account should not appear in the list of accounts anymore / the account profile should not be shown in the UI anymore.