### PR TITLE
feat(table): add access control for service account

### DIFF
--- a/src/verify/table_device.sql
+++ b/src/verify/table_device.sql
@@ -26,7 +26,7 @@ BEGIN
   ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.device', 'INSERT'));
   ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.device', 'UPDATE'));
   ASSERT NOT (SELECT pg_catalog.has_table_privilege('vibetype_anonymous', 'vibetype.device', 'DELETE'));
-  ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.device', 'SELECT'));
+  ASSERT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.device', 'SELECT'));
   ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.device', 'INSERT'));
   ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.device', 'UPDATE'));
   ASSERT NOT (SELECT pg_catalog.has_table_privilege(current_setting('role.vibetype_username'), 'vibetype.device', 'DELETE'));


### PR DESCRIPTION
Added the access control for the service account in the device table.

Also added the not null check in the fcm_token field