### PR TITLE
ci: set read permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   prepare_jobs:
     name: "Prepare: job optimization"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       pr_found: ${{ steps.pr.outputs.pr_found }}
     steps:

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release-schedule:
     name: "Release: Scheduled"
+    permissions:
+      contents: read
     uses: dargmuesli/github-actions/.github/workflows/release-schedule.yml@2.5.16
     secrets:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
It's recommended to specify the least needed permissions for all workflow jobs, so here we go with `contents: read`. If more are needed, the pipeline will surely complain.