### PR TITLE
perf: short-circuit row visibility for anonymous users

### DIFF
--- a/src/deploy/table_attendance_policy.sql
+++ b/src/deploy/table_attendance_policy.sql
@@ -68,7 +68,11 @@ USING (
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.attendance_via_own_events()) AS a WHERE a = attendance.id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype.guest_claim_array()) AS gc WHERE gc = attendance.guest_id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.attendance_via_own_contact()) AS a WHERE a = attendance.id)
-  OR vibetype_private.attendance_row_visible(attendance.guest_id)
+  OR CASE
+      WHEN vibetype.invoker_account_id() IS NOT NULL
+        THEN vibetype_private.attendance_row_visible(attendance.guest_id)
+      ELSE FALSE
+    END
 );
 
 -- Only the organizer may check a guest in (insert attendance).

--- a/src/deploy/table_guest_policy.sql
+++ b/src/deploy/table_guest_policy.sql
@@ -84,7 +84,11 @@ USING (
   EXISTS (SELECT 1 FROM unnest(vibetype.guest_claim_array()) AS gc WHERE gc = guest.id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.guests_via_own_contact()) AS g WHERE g = guest.id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.guests_via_own_events_unblocked()) AS g WHERE g = guest.id)
-  OR vibetype_private.guest_row_visible(guest.contact_id, guest.event_id)
+  OR CASE
+      WHEN vibetype.invoker_account_id() IS NOT NULL
+        THEN vibetype_private.guest_row_visible(guest.contact_id, guest.event_id)
+      ELSE FALSE
+    END
 );
 
 -- Only allow inserts for guests of events organized by oneself.
@@ -119,7 +123,11 @@ USING (
   EXISTS (SELECT 1 FROM unnest(vibetype.guest_claim_array()) AS gc WHERE gc = guest.id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.guests_via_own_contact()) AS g WHERE g = guest.id)
   OR EXISTS (SELECT 1 FROM unnest(vibetype_private.guests_via_own_events_unblocked()) AS g WHERE g = guest.id)
-  OR vibetype_private.guest_row_visible(guest.contact_id, guest.event_id)
+  OR CASE
+      WHEN vibetype.invoker_account_id() IS NOT NULL
+        THEN vibetype_private.guest_row_visible(guest.contact_id, guest.event_id)
+      ELSE FALSE
+    END
 );
 
 -- Only allow deletes for guests of events organized by oneself.

--- a/test/fixture/schema_vibetype.definition.sql
+++ b/test/fixture/schema_vibetype.definition.sql
@@ -6642,7 +6642,11 @@ CREATE POLICY attendance_select ON vibetype.attendance FOR SELECT USING (((EXIST
    FROM unnest(vibetype.guest_claim_array()) gc(gc)
   WHERE (gc.gc = attendance.guest_id))) OR (EXISTS ( SELECT 1
    FROM unnest(vibetype_private.attendance_via_own_contact()) a(a)
-  WHERE (a.a = attendance.id))) OR vibetype_private.attendance_row_visible(guest_id)));
+  WHERE (a.a = attendance.id))) OR
+CASE
+    WHEN (vibetype.invoker_account_id() IS NOT NULL) THEN vibetype_private.attendance_row_visible(guest_id)
+    ELSE false
+END));
 
 
 --
@@ -6956,7 +6960,11 @@ CREATE POLICY guest_select ON vibetype.guest FOR SELECT USING (((EXISTS ( SELECT
    FROM unnest(vibetype_private.guests_via_own_contact()) g(g)
   WHERE (g.g = guest.id))) OR (EXISTS ( SELECT 1
    FROM unnest(vibetype_private.guests_via_own_events_unblocked()) g(g)
-  WHERE (g.g = guest.id))) OR vibetype_private.guest_row_visible(contact_id, event_id)));
+  WHERE (g.g = guest.id))) OR
+CASE
+    WHEN (vibetype.invoker_account_id() IS NOT NULL) THEN vibetype_private.guest_row_visible(contact_id, event_id)
+    ELSE false
+END));
 
 
 --
@@ -6969,7 +6977,11 @@ CREATE POLICY guest_update ON vibetype.guest FOR UPDATE USING (((EXISTS ( SELECT
    FROM unnest(vibetype_private.guests_via_own_contact()) g(g)
   WHERE (g.g = guest.id))) OR (EXISTS ( SELECT 1
    FROM unnest(vibetype_private.guests_via_own_events_unblocked()) g(g)
-  WHERE (g.g = guest.id))) OR vibetype_private.guest_row_visible(contact_id, event_id)));
+  WHERE (g.g = guest.id))) OR
+CASE
+    WHEN (vibetype.invoker_account_id() IS NOT NULL) THEN vibetype_private.guest_row_visible(contact_id, event_id)
+    ELSE false
+END));
 
 
 --


### PR DESCRIPTION
This pull request tightens the visibility policies for `attendance` and `guest` records by requiring that the invoker's account ID is present before certain rows are considered visible. This adds an extra layer of access control, ensuring that visibility functions only apply when there is an authenticated user context.