### PR TITLE
feat(reccoom): add role

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Create role secrets
         run: |
           sudo mkdir -p /run/secrets
-          for role in grafana postgraphile vibetype zammad; do
+          for role in grafana postgraphile reccoom vibetype zammad; do
             echo "$role" | sudo tee "/run/secrets/postgres_role_service_${role}_username" > /dev/null
             echo "placeholder" | sudo tee "/run/secrets/postgres_role_service_${role}_password" > /dev/null
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,13 @@ RUN apt-get update \
   && echo "grafana"       > /run/secrets/postgres_role_service_grafana_username \
   && echo "postgres"      > /run/secrets/postgres_password \
   && echo "postgraphile"  > /run/secrets/postgres_role_service_postgraphile_username \
+  && echo "reccoom"       > /run/secrets/postgres_role_service_reccoom_username \
   && echo "vibetype"      > /run/secrets/postgres_role_service_vibetype_username \
   && echo "zammad"        > /run/secrets/postgres_role_service_zammad_username \
   && echo "placeholder" | tee \
     /run/secrets/postgres_role_service_grafana_password \
     /run/secrets/postgres_role_service_postgraphile_password \
+    /run/secrets/postgres_role_service_reccoom_password \
     /run/secrets/postgres_role_service_vibetype_password \
     /run/secrets/postgres_role_service_zammad_password \
     /dev/null

--- a/src/deploy/role_reccoom.sql
+++ b/src/deploy/role_reccoom.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+\set role_service_reccoom_password `cat /run/secrets/postgres_role_service_reccoom_password`
+\set role_service_reccoom_username `cat /run/secrets/postgres_role_service_reccoom_username`
+
+DROP ROLE IF EXISTS :role_service_reccoom_username;
+CREATE ROLE :role_service_reccoom_username LOGIN PASSWORD :'role_service_reccoom_password';
+
+GRANT SELECT ON TABLE vibetype.event TO :role_service_reccoom_username; -- TODO: move this to table event policy in next major release
+
+COMMIT;

--- a/src/revert/role_reccoom.sql
+++ b/src/revert/role_reccoom.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+\set role_service_reccoom_username `cat /run/secrets/postgres_role_service_reccoom_username`
+
+REVOKE ALL PRIVILEGES ON TABLE vibetype.event FROM :role_service_reccoom_username; -- TODO: remove this line in the next major release.
+DROP ROLE :role_service_reccoom_username;
+
+COMMIT;

--- a/src/sqitch
+++ b/src/sqitch
@@ -83,6 +83,8 @@ docker_sudo run --rm --network host \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_grafana_username.secret,dst=/run/secrets/postgres_role_service_grafana_username" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_password.secret,dst=/run/secrets/postgres_role_service_postgraphile_password" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_postgraphile_username.secret,dst=/run/secrets/postgres_role_service_postgraphile_username" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_reccoom_password.secret,dst=/run/secrets/postgres_role_service_reccoom_password" \
+    --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_reccoom_username.secret,dst=/run/secrets/postgres_role_service_reccoom_username" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_vibetype_password.secret,dst=/run/secrets/postgres_role_service_vibetype_password" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_vibetype_username.secret,dst=/run/secrets/postgres_role_service_vibetype_username" \
     --mount "type=bind,src=$THIS/../../stack/src/development/secrets/postgres/role_service_zammad_password.secret,dst=/run/secrets/postgres_role_service_zammad_password" \

--- a/src/sqitch.plan
+++ b/src/sqitch.plan
@@ -101,3 +101,4 @@ function_event_by_attendance_id [privilege_execute_revoke schema_public table_ev
 function_jwt_update_attendance_add [privilege_execute_revoke schema_private table_attendance function_invoker_account_id table_jwt type_jwt role_account role_anonymous] 2025-12-19T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add function to update JWT with attendance UUIDs.
 table_app [schema_public table_account_public role_account role_anonymous] 2025-12-20T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add table for apps with integrations that can be installed on events.
 table_event_app [table_app table_event table_account_public role_account role_anonymous] 2025-12-20T00:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add table for app installations on events.
+role_reccoom 2026-04-11T12:00:00Z Jonas Thelemann <e-mail+vibetype/sqitch@jonas-thelemann.de> # Add role reccoom.

--- a/src/verify/role_reccoom.sql
+++ b/src/verify/role_reccoom.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+\set role_service_reccoom_username `cat /run/secrets/postgres_role_service_reccoom_username`
+
+SET LOCAL role.service_reccoom_username TO :'role_service_reccoom_username';
+
+DO $$
+BEGIN
+  ASSERT (SELECT pg_catalog.pg_has_role(current_setting('role.service_reccoom_username'), 'USAGE'));
+END $$;
+
+ROLLBACK;

--- a/test/fixture/schema_vibetype.definition.sql
+++ b/test/fixture/schema_vibetype.definition.sql
@@ -7310,6 +7310,7 @@ GRANT ALL ON FUNCTION vibetype.create_guests(event_id uuid, contact_ids uuid[]) 
 
 GRANT SELECT ON TABLE vibetype.event TO vibetype_anonymous;
 GRANT SELECT,INSERT,DELETE,UPDATE ON TABLE vibetype.event TO vibetype_account;
+GRANT SELECT ON TABLE vibetype.event TO reccoom;
 
 
 --


### PR DESCRIPTION
This pull request introduces a new database role called `reccoom` for the Postgres setup, including its creation, privilege management, and integration with the deployment process. The changes ensure that the `reccoom` service has controlled access to the `vibetype.event` table and that secrets for this role are handled securely.
