### PR TITLE
feat(metadata)!: conditionally update updated by in metadata trigger

### DIFF
--- a/src/deploy/function_trigger_metadata_update.sql
+++ b/src/deploy/function_trigger_metadata_update.sql
@@ -3,10 +3,16 @@ CREATE FUNCTION vibetype.trigger_metadata_update() RETURNS trigger
     AS $$
 BEGIN
   NEW.updated_at = CURRENT_TIMESTAMP;
-  NEW.updated_by = vibetype.invoker_account_id();
+
+  BEGIN
+    NEW.updated_by = vibetype.invoker_account_id();
+  EXCEPTION
+    WHEN undefined_column THEN
+      NULL;
+  END;
 
   RETURN NEW;
 END;
 $$;
-COMMENT ON FUNCTION vibetype.trigger_metadata_update() IS 'Trigger function to automatically update metadata fields `updated_at` and `updated_by` when a row is modified. Sets `updated_at` to the current timestamp and `updated_by` to the account ID of the invoker.';
+COMMENT ON FUNCTION vibetype.trigger_metadata_update() IS 'Trigger function to automatically update metadata fields when a row is modified. Always sets `updated_at` to the current timestamp. Sets `updated_by` to the invoker account ID if the column exists on the table.';
 GRANT EXECUTE ON FUNCTION vibetype.trigger_metadata_update() TO vibetype_account;

--- a/test/fixture/schema_vibetype.definition.sql
+++ b/test/fixture/schema_vibetype.definition.sql
@@ -2036,7 +2036,13 @@ CREATE FUNCTION vibetype.trigger_metadata_update() RETURNS trigger
     AS $$
 BEGIN
   NEW.updated_at = CURRENT_TIMESTAMP;
-  NEW.updated_by = vibetype.invoker_account_id();
+
+  BEGIN
+    NEW.updated_by = vibetype.invoker_account_id();
+  EXCEPTION
+    WHEN undefined_column THEN
+      NULL;
+  END;
 
   RETURN NEW;
 END;
@@ -2049,7 +2055,7 @@ ALTER FUNCTION vibetype.trigger_metadata_update() OWNER TO ci;
 -- Name: FUNCTION trigger_metadata_update(); Type: COMMENT; Schema: vibetype; Owner: ci
 --
 
-COMMENT ON FUNCTION vibetype.trigger_metadata_update() IS 'Trigger function to automatically update metadata fields `updated_at` and `updated_by` when a row is modified. Sets `updated_at` to the current timestamp and `updated_by` to the account ID of the invoker.';
+COMMENT ON FUNCTION vibetype.trigger_metadata_update() IS 'Trigger function to automatically update metadata fields when a row is modified. Always sets `updated_at` to the current timestamp. Sets `updated_by` to the invoker account ID if the column exists on the table.';
 
 
 --

--- a/test/logic/main.sql
+++ b/test/logic/main.sql
@@ -77,6 +77,7 @@ GRANT USAGE ON SCHEMA vibetype_test TO vibetype_anonymous, vibetype_account;
 \i scenario/model/jwt_update_attendance_add.sql
 -- \i scenario/model/invite.sql -- TODO: remove comment when PR "feat(notification)!: inherit invitations" has been merged
 \i scenario/model/language_iso_full_text_search.sql
+\i scenario/model/trigger_metadata_update.sql
 
 \echo all tests completed successfully.
 

--- a/test/logic/scenario/model/trigger_metadata_update.sql
+++ b/test/logic/scenario/model/trigger_metadata_update.sql
@@ -1,0 +1,71 @@
+\echo test_trigger_metadata_update...
+
+BEGIN;
+
+SAVEPOINT update_sets_updated_at_and_updated_by;
+DO $$
+DECLARE
+  _account_id UUID;
+  _updated_at TIMESTAMPTZ;
+  _updated_by UUID;
+BEGIN
+  _account_id := vibetype_test.account_registration_verified('testuser', 'test@example.com');
+
+  CREATE TEMP TABLE test_metadata_full (
+    id SERIAL PRIMARY KEY,
+    updated_at TIMESTAMPTZ,
+    updated_by UUID
+  ) ON COMMIT DROP;
+
+  CREATE TRIGGER trigger_metadata_update
+    BEFORE UPDATE ON test_metadata_full
+    FOR EACH ROW EXECUTE FUNCTION vibetype.trigger_metadata_update();
+
+  INSERT INTO test_metadata_full DEFAULT VALUES;
+
+  PERFORM set_config('jwt.claims.sub', _account_id::TEXT, true);
+  UPDATE test_metadata_full SET id = id WHERE id = 1;
+  PERFORM set_config('jwt.claims.sub', '', true);
+
+  SELECT updated_at, updated_by INTO _updated_at, _updated_by
+    FROM test_metadata_full
+    WHERE id = 1;
+
+  IF _updated_at IS NULL THEN
+    RAISE EXCEPTION 'updated_at was not set on a table with updated_at and updated_by';
+  END IF;
+
+  IF _updated_by IS DISTINCT FROM _account_id THEN
+    RAISE EXCEPTION 'updated_by was not set to the invoker account id';
+  END IF;
+END $$;
+ROLLBACK TO SAVEPOINT update_sets_updated_at_and_updated_by;
+
+SAVEPOINT update_sets_updated_at_without_updated_by;
+DO $$
+DECLARE
+  _updated_at TIMESTAMPTZ;
+BEGIN
+  CREATE TEMP TABLE test_metadata_updated_at_only (
+    id SERIAL PRIMARY KEY,
+    updated_at TIMESTAMPTZ
+  ) ON COMMIT DROP;
+
+  CREATE TRIGGER trigger_metadata_update
+    BEFORE UPDATE ON test_metadata_updated_at_only
+    FOR EACH ROW EXECUTE FUNCTION vibetype.trigger_metadata_update();
+
+  INSERT INTO test_metadata_updated_at_only DEFAULT VALUES;
+
+  UPDATE test_metadata_updated_at_only SET id = id WHERE id = 1;
+
+  SELECT updated_at INTO _updated_at FROM test_metadata_updated_at_only WHERE id = 1;
+
+  IF _updated_at IS NULL THEN
+    RAISE EXCEPTION 'updated_at was not set on a table without updated_by';
+  END IF;
+END $$;
+ROLLBACK TO SAVEPOINT update_sets_updated_at_without_updated_by;
+
+ROLLBACK;
+


### PR DESCRIPTION
Only attempt to set the `updated_by` column if it exists on the table. This allows the trigger to be used on tables that track `updated_at` but do not include the `updated_by` field.